### PR TITLE
Cmake multiprocess

### DIFF
--- a/.github/workflows/espresso.yml
+++ b/.github/workflows/espresso.yml
@@ -40,7 +40,7 @@ jobs:
           mkdir build && cd build
           cp ../../myconfig.hpp .
           cmake ../ -D ESPRESSO_BUILD_WITH_FFTW=OFF
-          cmake --build .
+          cmake --build . -j $(nproc)
       - name: Run test suite
         run: |
           espresso/build/pypresso CI/run_espresso_test_suite.py

--- a/.github/workflows/espresso.yml
+++ b/.github/workflows/espresso.yml
@@ -40,7 +40,7 @@ jobs:
           mkdir build && cd build
           cp ../../myconfig.hpp .
           cmake ../ -D ESPRESSO_BUILD_WITH_FFTW=OFF
-          cmake --build . -j $(nproc)
+          cmake --build . -j 5
       - name: Run test suite
         run: |
           espresso/build/pypresso CI/run_espresso_test_suite.py


### PR DESCRIPTION
Adding generic multiprocessing call to cmake build to speed up the espresso tests. It should use all available cores on the server.