### PR TITLE
changed flax_network call method to operate on whole epoch data.

### DIFF
--- a/CI/unit_tests/losses/test_proximal_policy_loss.py
+++ b/CI/unit_tests/losses/test_proximal_policy_loss.py
@@ -13,6 +13,11 @@ class DummyActor:
         log_probs = 2.0 * np.ones((out_shape[0], out_shape[1], 4))
         return log_probs
 
+    def __call__(self, params, features):
+        out_shape = np.shape(features)
+        log_probs = 2.0 * np.ones((out_shape[0], out_shape[1], 4))
+        return log_probs
+
 
 class DummyCritic:
     def __call__(self, features):

--- a/CI/unit_tests/networks/test_flax_network.py
+++ b/CI/unit_tests/networks/test_flax_network.py
@@ -88,8 +88,10 @@ class TestFlaxNetwork:
             sampling_strategy=self.sampling_strategy,
             exploration_policy=self.exploration_policy,
         )
-        input_vector = np.array([1.0, 2.0])
-        pre_save_output = pre_save_model(input_vector)
+        input_vector = np.array([[1.0, 2.0]])
+        pre_save_output = pre_save_model(
+            {"params": pre_save_model.model_state.params}, input_vector
+        )
         pre_save_model.export_model(filename="model", directory="Models")
 
         # Check if the model exists
@@ -103,7 +105,9 @@ class TestFlaxNetwork:
             sampling_strategy=self.sampling_strategy,
             exploration_policy=self.exploration_policy,
         )
-        post_save_output = post_save_model(input_vector)
+        post_save_output = post_save_model(
+            {"params": post_save_model.model_state.params}, input_vector
+        )
 
         # Check that the output is different
         np.testing.assert_raises(
@@ -115,7 +119,9 @@ class TestFlaxNetwork:
 
         # Load the model state
         post_save_model.restore_model_state(directory="Models", filename="model")
-        post_restore_output = post_save_model(input_vector)
+        post_restore_output = post_save_model(
+            {"params": post_save_model.model_state.params}, input_vector
+        )
         np.testing.assert_array_equal(pre_save_output, post_restore_output)
 
         # Check that the epoch counts are equal

--- a/CI/unit_tests/networks/test_flax_network.py
+++ b/CI/unit_tests/networks/test_flax_network.py
@@ -68,7 +68,7 @@ class TestFlaxNetwork:
         )
         input_data = np.array([[1.0, 2.0], [4.0, 5.0]])
 
-        data_from_call = model(input_data)
+        data_from_call = model({"params": model.model_state.params}, input_data)
         action_indices, action_logits = model.compute_action(input_data)
 
         # Check shapes

--- a/swarmrl/losses/policy_gradient_loss.py
+++ b/swarmrl/losses/policy_gradient_loss.py
@@ -88,8 +88,7 @@ class PolicyGradientLoss(Loss):
         value_function_values = self.value_function(rewards)
         logger.debug(f"{value_function_values.shape}")
 
-        critic_apply_fn = jax.vmap(critic.__call__, in_axes=(0))
-        critic_values = critic_apply_fn(feature_data)[
+        critic_values = critic({"params": critic.model_state.params}, feature_data)[
             :, :, 0
         ]  # zero for trivial dimension
         logger.debug(f"{critic_values.shape=}")

--- a/swarmrl/networks/flax_network.py
+++ b/swarmrl/networks/flax_network.py
@@ -65,6 +65,7 @@ class FlaxModel(Network, ABC):
         self.sampling_strategy = sampling_strategy
         self.model = flax_model
         self.apply_fn = jax.jit(self.model.apply)
+        self.vapply_fn = jax.vmap(self.apply_fn, in_axes=(None, 0))
         self.input_shape = input_shape
         self.model_state = None
 
@@ -217,7 +218,7 @@ class FlaxModel(Network, ABC):
         )
         self.epoch_count = epoch
 
-    def __call__(self, feature_vector: np.ndarray):
+    def __call__(self, params, feature_vector: np.ndarray):
         """
         See parent class for full doc string.
 
@@ -233,6 +234,6 @@ class FlaxModel(Network, ABC):
         """
 
         try:
-            return self.apply_fn({"params": self.model_state.params}, feature_vector)
+            return self.vapply_fn(params, feature_vector)
         except AttributeError:  # We need this for loaded models.
-            return self.apply_fn({"params": self.model_state["params"]}, feature_vector)
+            return self.vapply_fn(params, feature_vector)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #

#### Summary of additions and changes

* the call method of a flax newtwork now uses a vectorized version of the apply_fn. It can operate on an array of feature data to compute logits/values for a whole episode
* in the loss, the vectroized versions are called

#### How to test this pull request

```

```