### PR TITLE
Add flow, potential, langevin

### DIFF
--- a/.github/workflows/espresso.yml
+++ b/.github/workflows/espresso.yml
@@ -38,7 +38,7 @@ jobs:
           git clone https://github.com/espressomd/espresso.git
           cd espresso
           mkdir build && cd build
-          cp ../../myconfig.hpp .
+          cp ../maintainer/configs/maxset.hpp myconfig.hpp .
           cmake ../ -D ESPRESSO_BUILD_WITH_FFTW=OFF
           cmake --build . -j 5
       - name: Run test suite

--- a/.github/workflows/espresso.yml
+++ b/.github/workflows/espresso.yml
@@ -38,7 +38,7 @@ jobs:
           git clone https://github.com/espressomd/espresso.git
           cd espresso
           mkdir build && cd build
-          cp ../maintainer/configs/maxset.hpp myconfig.hpp .
+          cp ../maintainer/configs/maxset.hpp myconfig.hpp
           cmake ../ -D ESPRESSO_BUILD_WITH_FFTW=OFF
           cmake --build . -j 5
       - name: Run test suite

--- a/CI/espresso_tests/integration_tests/test_genetic_deployment.py
+++ b/CI/espresso_tests/integration_tests/test_genetic_deployment.py
@@ -15,10 +15,11 @@ from swarmrl.models.interaction_model import Action
 
 
 # Helper definitions.
-def get_simulation_runner(directory):
+def get_simulation_runner():
     """
     Collect a simulation runner.
     """
+    simulation_name = "training"
     seed = int(np.random.uniform(1, 100))
 
     temperature = 297.15
@@ -31,8 +32,8 @@ def get_simulation_runner(directory):
         WCA_epsilon=ureg.Quantity(temperature, "kelvin") * ureg.boltzmann_constant,
         temperature=ureg.Quantity(300.0, "kelvin"),
         box_length=ureg.Quantity(1000, "micrometer"),
-        time_slice=ureg.Quantity(0.5, "second"),
-        time_step=ureg.Quantity(0.5, "second") / 5,
+        time_slice=ureg.Quantity(0.5, "second"),  # model timestep
+        time_step=ureg.Quantity(0.5, "second") / 5,  # integrator timestep
         write_interval=ureg.Quantity(2, "second"),
     )
 
@@ -40,7 +41,7 @@ def get_simulation_runner(directory):
         md_params=md_params,
         n_dims=2,
         seed=seed,
-        out_folder=directory,
+        out_folder=simulation_name,
         write_chunk_size=100,
     )
 

--- a/CI/espresso_tests/integration_tests/test_genetic_deployment.py
+++ b/CI/espresso_tests/integration_tests/test_genetic_deployment.py
@@ -1,8 +1,8 @@
 """
 Integration test for the genetic algorithm training.
 """
-import tempfile
 
+import tempfile
 import unittest as ut
 
 import flax.linen as nn

--- a/CI/espresso_tests/integration_tests/test_genetic_deployment.py
+++ b/CI/espresso_tests/integration_tests/test_genetic_deployment.py
@@ -148,9 +148,9 @@ class TestGeneticTraining(ut.TestCase):
                 get_simulation_runner,
                 n_episodes=50,
                 output_directory=temp_dir,
-                episode_length=20,
+                episode_length=30,
                 number_of_generations=5,
-                population_size=4,
+                population_size=6,
                 number_of_parents=3,
                 parallel_jobs=2,
             )

--- a/CI/espresso_tests/unit_tests/test_anisotropic_particles.py
+++ b/CI/espresso_tests/unit_tests/test_anisotropic_particles.py
@@ -42,15 +42,17 @@ class EspressoTestAnisotropic(ut.TestCase):
             equatorial_semiaxis = radius / np.cbrt(aspect_ratio)
             axial_semiaxis = equatorial_semiaxis * aspect_ratio
 
-            gamma_trans_ax, gamma_trans_eq = (
-                swarmrl.utils.calc_ellipsoid_friction_factors_translation(
-                    axial_semiaxis, equatorial_semiaxis, params.fluid_dyn_viscosity
-                )
+            (
+                gamma_trans_ax,
+                gamma_trans_eq,
+            ) = swarmrl.utils.calc_ellipsoid_friction_factors_translation(
+                axial_semiaxis, equatorial_semiaxis, params.fluid_dyn_viscosity
             )
-            gamma_rot_ax, gamma_rot_eq = (
-                swarmrl.utils.calc_ellipsoid_friction_factors_rotation(
-                    axial_semiaxis, equatorial_semiaxis, params.fluid_dyn_viscosity
-                )
+            (
+                gamma_rot_ax,
+                gamma_rot_eq,
+            ) = swarmrl.utils.calc_ellipsoid_friction_factors_rotation(
+                axial_semiaxis, equatorial_semiaxis, params.fluid_dyn_viscosity
             )
 
             gamma_trans = swarmrl.utils.convert_array_of_pint_to_pint_of_array(

--- a/CI/espresso_tests/unit_tests/test_flow.py
+++ b/CI/espresso_tests/unit_tests/test_flow.py
@@ -1,0 +1,159 @@
+import tempfile
+import unittest as ut
+
+import numpy as np
+import pint
+
+from swarmrl.engine import espresso
+from swarmrl.models import dummy_models
+from swarmrl.utils import utils
+
+
+class FlowTest(ut.TestCase):
+    def test_flow_and_potential(self):
+        """
+        Set up a 2d simulation with flow and boundaries.
+        Also introduces the tricks needed to perform physcially meaningful simulations.
+        """
+        ureg = pint.UnitRegistry()
+        langevin_friction_scale = 1e-6  # to avoid double-friction, see below
+        params = espresso.MDParams(
+            ureg=ureg,
+            fluid_dyn_viscosity=ureg.Quantity(8.9e-3, "pascal * second"),
+            WCA_epsilon=ureg.Quantity(300, "kelvin") * ureg.boltzmann_constant,
+            temperature=ureg.Quantity(300, "kelvin") / langevin_friction_scale,
+            box_length=ureg.Quantity(100, "micrometer"),
+            time_step=ureg.Quantity(0.1, "second") / 100,
+            time_slice=ureg.Quantity(0.01, "second"),
+            write_interval=ureg.Quantity(5, "second"),
+            thermostat_type="langevin",
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runner = espresso.EspressoMD(
+                params, out_folder=temp_dir, write_chunk_size=1, n_dims=2
+            )
+
+            # create a 2d flowfield. Usually, this would be done in a
+            # separate (lattice Boltzmann) simulation
+            # note that at swarmrl only supports cubic simulation boxes
+            n_cells = 100
+            box_l = params.box_length.m_as("sim_length")
+            agrid_SI = params.box_length / n_cells
+            agrid = box_l / n_cells
+            xs = np.linspace(
+                0.5 * agrid, box_l - 0.5 * agrid, num=n_cells, endpoint=True
+            )
+            ys = xs
+            xv, yv = np.meshgrid(xs, ys)
+
+            flow = 3 * np.stack(
+                [np.ones_like(xv), 0.1 * np.cos(yv) * np.sin(xv), np.zeros_like(xv)],
+                axis=2,
+            )
+            flow = ureg.Quantity(flow, "micrometer/second")
+
+            # create binary mask of boundary: circular domain
+            rs = np.sqrt((xv - box_l / 2.0) ** 2 + (yv - box_l / 2.0) ** 2)
+            boundary_mask = rs > box_l / 2.0 - agrid
+
+            # Before adding the flowfield, we need to know the coupling gamma
+            coll_radius = ureg.Quantity(1, "micrometer")
+            gamma = 6 * np.pi * params.fluid_dyn_viscosity * coll_radius
+
+            # flowfield must be 3d, so we add z-axis
+            runner.add_flowfield(
+                flow[:, :, np.newaxis, :],
+                gamma,
+                utils.convert_array_of_pint_to_pint_of_array(
+                    [agrid_SI, agrid_SI, params.box_length], ureg
+                ),
+            )
+
+            """
+            force at the boundary comes from interpolation of step potential
+            across one agrid, so force=potential_jump/agrid
+            choose potential jump such that force is
+            larger than swim force + drag force
+            """
+            swim_vel = ureg.Quantity(5, "micrometer/second")
+            swim_force = gamma * swim_vel
+            potential = (
+                2 * (swim_force + np.max(flow) * gamma) * agrid_SI * boundary_mask
+            )
+            runner.add_external_potential(
+                potential[:, :, np.newaxis],
+                utils.convert_array_of_pint_to_pint_of_array(
+                    [agrid_SI, agrid_SI, params.box_length], ureg
+                ),
+            )
+
+            """
+            Flow constraint introduces friction.
+            Thermostat has friction and noise.
+            To avoid double-friction, we need to get rid of the thermostat
+            friction while retaining the noise. Langevin noise scales with kT*gamma,
+            so we must keep the product constant while reducing the gamma.
+            This is why the temperature in MDParams is increased.
+            For rotation, the flow does not introduce additional friction,
+            so we need to cope with the reduced temperature:
+            1) The thermostat rotational friction must be increased
+            to get the correct noise amplitude.
+            2) All torques (e.g. the ones from actions) must be increased
+            to reflect the increased rotational friction.
+            """
+
+            gamma_trans_reduced = gamma * langevin_friction_scale
+            gamma_rot_increased = (
+                8
+                * np.pi
+                * params.fluid_dyn_viscosity
+                * coll_radius**3
+                / langevin_friction_scale
+            )
+            active_ang_vel = ureg.Quantity(4 * np.pi / 180, "1/second")
+
+            """
+            We can't do actual langevin dynamics of the colloids
+            (momentum relaxation timescale is way too small to resolve).
+            By increasing the particle mass, we bring the momentum relaxation
+            closer to the timescales we are interested in (and can resolve).
+            However, we cannot increase too much, because at some point
+            there will be inertial effects. Here, we choose 0.01 seconds such that
+            the momentum relaxation is much faster than the change in actions.
+            For production simulations you should consider using an even smaller
+            value to actually have the timescales separated.
+            """
+            target_momentum_relaxation_timescale = ureg.Quantity(0.01, "second")
+            partcl_mass = gamma * target_momentum_relaxation_timescale
+            partcl_rinertia = gamma_rot_increased * target_momentum_relaxation_timescale
+
+            runner.add_colloids(
+                10,
+                coll_radius,
+                ureg.Quantity([50, 50, 0], "micrometer"),
+                ureg.Quantity(30, "micrometer"),
+                gamma_translation=gamma_trans_reduced,
+                gamma_rotation=gamma_rot_increased,
+                mass=partcl_mass,
+                rinertia=utils.convert_array_of_pint_to_pint_of_array(
+                    3 * [partcl_rinertia], ureg
+                ),
+            )
+
+            active_force = swim_force.m_as("sim_force")
+            active_torque = (active_ang_vel * gamma_rot_increased).m_as("sim_torque")
+
+            model = dummy_models.ConstForceAndTorque(
+                active_force, [0, 0, active_torque]
+            )
+
+            runner.integrate(1000, force_model=model)
+
+            # particles should be advected to the right until they hit the boundary
+            poss = runner.get_particle_data()["Unwrapped_Positions"]
+            np.testing.assert_array_less(box_l / 2.0, np.mean(poss[:, 0]))
+            np.testing.assert_array_less(poss[:, 0], box_l)
+
+
+if __name__ == "__main__":
+    ut.main()

--- a/CI/unit_tests/utils/test_utils.py
+++ b/CI/unit_tests/utils/test_utils.py
@@ -163,10 +163,11 @@ class TestUtils:
             axial_semiaxis, equatorial_semiaxis, 5
         )
         assert gamma_rot_eq > gamma_rot_ax
-        gamma_trans_ax, gamma_trans_eq = (
-            utils.calc_ellipsoid_friction_factors_translation(
-                axial_semiaxis, equatorial_semiaxis, 5
-            )
+        (
+            gamma_trans_ax,
+            gamma_trans_eq,
+        ) = utils.calc_ellipsoid_friction_factors_translation(
+            axial_semiaxis, equatorial_semiaxis, 5
         )
         assert gamma_trans_eq > gamma_trans_ax
 
@@ -177,9 +178,10 @@ class TestUtils:
             axial_semiaxis, equatorial_semiaxis, 5
         )
         assert gamma_rot_ax > gamma_rot_eq
-        gamma_trans_ax, gamma_trans_eq = (
-            utils.calc_ellipsoid_friction_factors_translation(
-                axial_semiaxis, equatorial_semiaxis, 5
-            )
+        (
+            gamma_trans_ax,
+            gamma_trans_eq,
+        ) = utils.calc_ellipsoid_friction_factors_translation(
+            axial_semiaxis, equatorial_semiaxis, 5
         )
         assert gamma_trans_ax > gamma_trans_eq

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -317,6 +317,19 @@ class EspressoMD(Engine):
                     "If you use the Langevin thermostat, you must set a particle"
                     " rotational inertia"
                 )
+        else:
+            # mass and moment of inertia can still be relevant when calculating
+            # the stochastic part of the particle velocity, see
+            # https://espressomd.github.io/doc/integration.html#brownian-thermostat.
+            # Provide defaults in case the user didn't set the values.
+            water_dens = self.params.ureg.Quantity(1000, "kg/meter**3")
+            if mass is None:
+                mass = water_dens * 4.0 / 3.0 * np.pi * radius_colloid**3
+            if rinertia is None:
+                rinertia = 2.0 / 5.0 * mass * radius_colloid**2
+                rinertia = utils.convert_array_of_pint_to_pint_of_array(
+                    3 * [rinertia], self.params.ureg
+                )
 
         if self.n_dims == 3:
             colloid = self.system.part.add(

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -38,6 +38,10 @@ class MDParams:
         MD runs with internal time step of time_step. The external force/torque from
         the force_model will not be updated at every single time step, instead every
         time_slice. Therefore, time_slice must be an integer multiple of time_step.
+    thermostat_type: optional
+        One of "brownian", "langevin",
+        see https://espressomd.github.io/doc/integration.html
+        for details of the algorithms.
     """
 
     ureg: pint.UnitRegistry
@@ -48,6 +52,7 @@ class MDParams:
     time_step: pint.Quantity
     time_slice: pint.Quantity
     write_interval: pint.Quantity
+    thermostat_type: str = "brownian"
 
 
 def _get_random_start_pos(
@@ -114,7 +119,7 @@ class EspressoMD(Engine):
         periodic : bool
                 If False, do not use periodic boundary conditions.
         """
-        self.params = md_params
+        self.params: MDParams = md_params
         self.out_folder = out_folder
         self.seed = seed
         self.rng = np.random.default_rng(self.seed)
@@ -163,6 +168,7 @@ class EspressoMD(Engine):
         self.ureg.define("sim_velocity = sim_length / sim_time")
         self.ureg.define("sim_angular_velocity = 1 / sim_time")
         self.ureg.define("sim_mass = sim_energy / sim_velocity**2")
+        self.ureg.define("sim_rinertia = sim_length**2 * sim_mass")
         self.ureg.define("sim_dyn_viscosity = sim_mass / (sim_length * sim_time)")
         self.ureg.define("sim_force = sim_mass * sim_length / sim_time**2")
         self.ureg.define("sim_torque = sim_length * sim_force")
@@ -235,6 +241,8 @@ class EspressoMD(Engine):
         gamma_translation: pint.Quantity = None,
         gamma_rotation: pint.Quantity = None,
         aspect_ratio: float = 1.0,
+        mass: pint.Quantity = None,
+        rinertia: pint.Quantity = None,
     ):
         """
         Parameters
@@ -247,15 +255,20 @@ class EspressoMD(Engine):
             Multiple calls can be made with the same type_colloid.
             Interaction models need to be made aware if there are different types
             of colloids in the system if specific behaviour is desired.
-        gamma_translation, gamma_rotation: optional
+        gamma_translation, gamma_rotation: pint.Quantity[np.array], optional
             If None, calculate these quantities from the radius and the fluid viscosity.
             You can provide friction coefficients as scalars or a 3-vector
             (the diagonal elements of the friction tensor).
-        aspect_ratio
+        aspect_ratio: float, optional
             If you provide a value != 1, a gay-berne interaction will be set up
             instead of purely repulsive lennard jones.
             aspect_ratio > 1 will produce a cigar, aspect_ratio < 0 a disk
             (both swimming in the direction of symmetry).
+        mass: optional
+            Particle mass. Only relevant for Langevin integrator.
+        rinertia: optional
+            Diagonal elements of the rotational moment of inertia tensor
+            of the particle, assuming the particle is oriented along z.
 
         Returns
         -------
@@ -294,6 +307,17 @@ class EspressoMD(Engine):
         else:
             gamma_rotation = gamma_rotation.m_as("sim_torque/sim_angular_velocity")
 
+        if self.params.thermostat_type == "langevin":
+            if mass is None:
+                raise ValueError(
+                    "If you use the Langevin thermostat, you must set a particle mass"
+                )
+            if rinertia is None:
+                raise ValueError(
+                    "If you use the Langevin thermostat, you must set a particle"
+                    " rotational inertia"
+                )
+
         if self.n_dims == 3:
             colloid = self.system.part.add(
                 pos=init_pos,
@@ -303,6 +327,8 @@ class EspressoMD(Engine):
                 gamma_rot=gamma_rotation,
                 fix=3 * [False],
                 type=type_colloid,
+                mass=mass.m_as("sim_mass"),
+                rinertia=rinertia.m_as("sim_rinertia"),
             )
         else:
             # initialize with body-frame = lab-frame to set correct rotation flags
@@ -316,6 +342,8 @@ class EspressoMD(Engine):
                 gamma_rot=gamma_rotation,
                 quat=[1, 0, 0, 0],
                 type=type_colloid,
+                mass=mass.m_as("sim_mass"),
+                rinertia=rinertia.m_as("sim_rinertia"),
             )
             theta, phi = utils.angles_from_vector(init_direction)
             if abs(theta - np.pi / 2) > 10e-6:
@@ -344,6 +372,8 @@ class EspressoMD(Engine):
         gamma_translation: pint.Quantity = None,
         gamma_rotation: pint.Quantity = None,
         aspect_ratio: float = 1.0,
+        mass: pint.Quantity = None,
+        rinertia: pint.Quantity = None,
     ):
         """
         Parameters
@@ -367,6 +397,12 @@ class EspressoMD(Engine):
             aspect_ratio > 1 will produce a cigar, aspect_ratio < 0 a disk
             (both swimming in the direction of symmetry).
             The radius_colloid gives the radius perpendicular to the symmetry axis.
+        mass: optional
+            Particle mass. Only relevant for Langevin integrator.
+        rinertia: optional
+            Diagonal elements of the rotational moment of inertia tensor
+            of the particle, assuming the particle is oriented along z.
+
 
         Returns
         -------
@@ -385,30 +421,23 @@ class EspressoMD(Engine):
             )
 
             if self.n_dims == 3:
-                director = utils.vector_from_angles(*utils.get_random_angles(self.rng))
-                self.add_colloid_on_point(
-                    radius_colloid=radius_colloid,
-                    init_position=start_pos,
-                    init_direction=director,
-                    type_colloid=type_colloid,
-                    gamma_translation=gamma_translation,
-                    gamma_rotation=gamma_rotation,
-                    aspect_ratio=aspect_ratio,
+                init_direction = utils.vector_from_angles(
+                    *utils.get_random_angles(self.rng)
                 )
             else:
-                # initialize with body-frame = lab-frame to set correct rotation flags
-                # allow all rotations to bring the particle to correct state
                 start_angle = 2 * np.pi * self.rng.random()
                 init_direction = utils.vector_from_angles(np.pi / 2, start_angle)
-                self.add_colloid_on_point(
-                    radius_colloid=radius_colloid,
-                    init_position=start_pos,
-                    init_direction=init_direction,
-                    type_colloid=type_colloid,
-                    gamma_translation=gamma_translation,
-                    gamma_rotation=gamma_rotation,
-                    aspect_ratio=aspect_ratio,
-                )
+            self.add_colloid_on_point(
+                radius_colloid=radius_colloid,
+                init_position=start_pos,
+                init_direction=init_direction,
+                type_colloid=type_colloid,
+                gamma_translation=gamma_translation,
+                gamma_rotation=gamma_rotation,
+                aspect_ratio=aspect_ratio,
+                mass=mass,
+                rinertia=rinertia,
+            )
 
     def add_rod(
         self,
@@ -694,6 +723,104 @@ class EspressoMD(Engine):
             )
         parts.ext_force = force_simunits
 
+    def add_flowfield(
+        self,
+        flowfield: pint.Quantity,
+        friction_coeff: pint.Quantity,
+        grid_spacings: pint.Quantity,
+    ):
+        """
+        Parameters
+        ----------
+        flowfield: pint.Quantity[np.array]
+            The flowfield to add, given as a pint Quantity of a numpy array
+            with units of velocity.
+            Must have shape (n_cells_x, n_cells_y, n_cells_z, 3)
+            The velocity values must be centered in the corresponding grid,
+            e.g. the [idx_x,idx_y,idx_z, :] value of the array contains the velocity at
+            np.dot([idx_x+0.5,idx_y+0.5,idx_z+0.5],[agrid_x,agrid_y,agrid_z]).
+            From these points, the velocity is interpolated to the particle positions.
+        friction_coeff: pint.Quantity[float]
+            The friction coefficient in units of mass/time.
+            Espresso does not yet support particle-specific or anisotropic
+            friction coefficients for flow coupling, so one scalar value has to be
+            provided here which will be used for all particles.
+        grid_spacings: pint.Quantity[np.array]
+            This grid spacing will be used to fit the flowfield into the simulation box.
+            If you run a 2d-simulation, choose grid_spacings[2]=box_l.
+        """
+
+        if not self.params.thermostat_type == "langevin":
+            raise RuntimeError(
+                "Coupling to a flowfield does not work with a Brownian thermostat. Use"
+                " 'langevin'."
+            )
+
+        flow = flowfield.m_as("sim_velocity")
+        gamma = friction_coeff.m_as("sim_mass/sim_time")
+        agrids = grid_spacings.m_as("sim_length")
+
+        if not flow.ndim == 4:
+            raise ValueError(
+                "flowfield must have shape (n_cells_x, n_cells_y, n_cells_z, 3)"
+            )
+        if not len(grid_spacings) == 3:
+            raise ValueError("Grid spacings must have length of 3")
+
+        # espresso constraint field must be one grid larger in all directions
+        # for interpolation. Apply periodic boundary conditions
+        flow_padded = np.stack(
+            [np.pad(flow[:, :, :, i], mode="wrap", pad_width=1) for i in range(3)],
+            axis=3,
+        )
+        flow_constraint = espressomd.constraints.FlowField(
+            field=flow_padded, gamma=gamma, grid_spacing=agrids
+        )
+        self.system.constraints.add(flow_constraint)
+
+    def add_external_potential(
+        self, potential: pint.Quantity, grid_spacings: pint.Quantity
+    ):
+        """
+        Parameters
+        ----------
+        potential: pint.Quantity[np.array]
+            The flowfield to add, given as a pint Quantity of a numpy array
+            with units of energy.
+            Must have shape (n_cells_x, n_cells_y, n_cells_z)
+            The potential values must be centered in the corresponding grid,
+            e.g. the [idx_x,idx_y,idx_z, :] value of the array contains the potential at
+            np.dot([idx_x+0.5, idx_y+0.5, idx_z+0.5], [agrid_x, agrid_y, agrid_z]).
+            From these points, the potential is interpolated to the particle positions.
+        grid_spacings: pint.Quantity[np.array]
+            This grid spacing will be used to fit the potential into the simulation box.
+            If you run a 2d-simulation, choose grid_spacings[2]=box_l.
+        """
+
+        pot = potential.m_as("sim_energy")
+        agrids = grid_spacings.m_as("sim_length")
+
+        if not pot.ndim == 3:
+            raise ValueError(
+                "potential must have shape (n_cells_x, n_cells_y, n_cells_z)"
+            )
+        if not len(grid_spacings) == 3:
+            raise ValueError("Grid spacings must have length of 3")
+
+        # Espresso constraint field must be one cell larger in all directions
+        # for interpolation. Apply periodic boundary conditions.
+        pot_padded = np.pad(
+            pot,
+            pad_width=1,
+            mode="wrap",
+        )
+        pot_constraint = espressomd.constraints.PotentialField(
+            field=pot_padded[:, :, :, np.newaxis],
+            grid_spacing=agrids,
+            default_scale=1.0,
+        )
+        self.system.constraints.add(pot_constraint)
+
     def get_friction_coefficients(self, type: int):
         """
         Returns both the translational and the rotational friction coefficient
@@ -820,18 +947,33 @@ class EspressoMD(Engine):
         )
         self.system.integrator.run(1000)
 
-        # set the brownian thermostat
+        # set the thermostat
         kT = (self.params.temperature * self.ureg.boltzmann_constant).m_as("sim_energy")
+
+        allowed_integrators = ["brownian", "langevin"]
+        if self.params.thermostat_type not in allowed_integrators:
+            raise ValueError(f"integrator_type must be one of {allowed_integrators}")
+
         # Dummy gamma values, we set them for each particle separately.
         # If we forget to do so, the simulation will explode as a gentle reminder
-        self.system.thermostat.set_brownian(
-            kT=kT,
-            gamma=1e-20,
-            gamma_rotation=1e-20,
-            seed=self.seed,
-            act_on_virtual=False,
-        )
-        self.system.integrator.set_brownian_dynamics()
+        if self.params.thermostat_type == "brownian":
+            self.system.thermostat.set_brownian(
+                kT=kT,
+                gamma=1e-20,
+                gamma_rotation=1e-20,
+                seed=self.seed,
+                act_on_virtual=False,
+            )
+            self.system.integrator.set_brownian_dynamics()
+        else:
+            self.system.thermostat.set_langevin(
+                kT=kT,
+                gamma=1e-20,
+                gamma_rotation=1e-20,
+                seed=self.seed,
+                act_on_virtual=False,
+            )
+            self.system.integrator.set_vv()
 
     def manage_forces(self, force_model: swarmrl.models.InteractionModel = None):
         swarmrl_colloids = []

--- a/swarmrl/models/dummy_models.py
+++ b/swarmrl/models/dummy_models.py
@@ -21,6 +21,14 @@ class ConstTorque(interaction_model.InteractionModel):
         return len(colloids) * [self.action]
 
 
+class ConstForceAndTorque(interaction_model.InteractionModel):
+    def __init__(self, force: float, torque: np.ndarray):
+        self.action = interaction_model.Action(force=force, torque=torque)
+
+    def calc_action(self, colloids) -> typing.List[interaction_model.Action]:
+        return len(colloids) * [self.action]
+
+
 class ToConstDirection(interaction_model.InteractionModel):
     def __init__(self, direction: np.ndarray):
         self.action = interaction_model.Action(new_direction=direction)


### PR DESCRIPTION
- Add external potential to simulations via interpolation on grid
- Add flow to simulations via interpolation on grid
- Choose langevin or brownian thermostat (Brownian has random velocities, can't be used with flow field)
- Add test that covers all the tricks necessary to run a simulation of particles constrained in a geometry with flow