### PR TITLE
Fix the two training routines in SwarmRL

### DIFF
--- a/CI/espresso_tests/integration_tests/test_ensemble_deployment.py
+++ b/CI/espresso_tests/integration_tests/test_ensemble_deployment.py
@@ -149,10 +149,10 @@ class TestEnsembleTraining(ut.TestCase):
                 rl_trainer,
                 get_simulation_runner,
                 output_dir=temp_dir,
-                number_of_ensembles=4,
-                n_episodes=5,
+                number_of_ensembles=6,
+                n_episodes=50,
                 n_parallel_jobs=2,
-                episode_length=5,
+                episode_length=20,
             )
 
             self.training_routine.train_ensemble()

--- a/CI/espresso_tests/integration_tests/test_ensemble_deployment.py
+++ b/CI/espresso_tests/integration_tests/test_ensemble_deployment.py
@@ -40,7 +40,7 @@ def get_simulation_runner():
         md_params=md_params,
         n_dims=2,
         seed=seed,
-        out_folder=+"." + "/" + simulation_name,
+        out_folder="." + "/" + simulation_name,
         write_chunk_size=100,
     )
 
@@ -56,26 +56,16 @@ def get_simulation_runner():
     return system_runner
 
 
-class ActorNet(nn.Module):
+class Network(nn.Module):
     """A simple dense model."""
 
     @nn.compact
     def __call__(self, x):
         x = nn.Dense(features=128)(x)
         x = nn.relu(x)
+        y = nn.Dense(features=1)(x)
         x = nn.Dense(features=4)(x)
-        return x
-
-
-class CriticNet(nn.Module):
-    """A simple dense model."""
-
-    @nn.compact
-    def __call__(self, x):
-        x = nn.Dense(features=128)(x)
-        x = nn.relu(x)
-        x = nn.Dense(features=1)(x)
-        return x
+        return x, y
 
 
 def scale_function(distance: float):
@@ -122,18 +112,12 @@ class TestEnsembleTraining(ut.TestCase):
             # Define the loss model
             loss = srl.losses.PolicyGradientLoss(value_function=value_function)
 
-            actor = srl.networks.FlaxModel(
-                flax_model=ActorNet(),
+            network = srl.networks.FlaxModel(
+                flax_model=Network(),
                 optimizer=optax.adam(learning_rate=0.001),
                 input_shape=(1,),
                 sampling_strategy=sampling_strategy,
                 exploration_policy=exploration_policy,
-            )
-
-            critic = srl.networks.FlaxModel(
-                flax_model=CriticNet(),
-                optimizer=optax.adam(learning_rate=0.001),
-                input_shape=(1,),
             )
 
             translate = Action(force=10.0)
@@ -150,8 +134,7 @@ class TestEnsembleTraining(ut.TestCase):
 
             protocol = srl.rl_protocols.ActorCritic(
                 particle_type=0,
-                actor=actor,
-                critic=critic,
+                network=network,
                 task=task,
                 observable=observable,
                 actions=actions,
@@ -165,10 +148,10 @@ class TestEnsembleTraining(ut.TestCase):
                 rl_trainer,
                 get_simulation_runner,
                 output_dir=temp_dir,
-                number_of_ensembles=20,
-                n_episodes=50,
+                number_of_ensembles=4,
+                n_episodes=5,
                 n_parallel_jobs=2,
-                episode_length=20,
+                episode_length=5,
             )
 
             self.training_routine.train_ensemble()

--- a/CI/espresso_tests/integration_tests/test_genetic_deployment.py
+++ b/CI/espresso_tests/integration_tests/test_genetic_deployment.py
@@ -146,10 +146,10 @@ class TestGeneticTraining(ut.TestCase):
             self.training_routine = srl.training_routines.GeneticTraining(
                 rl_trainer,
                 get_simulation_runner,
-                n_episodes=10,
+                n_episodes=50,
                 output_directory=temp_dir,
-                episode_length=5,
-                number_of_generations=2,
+                episode_length=20,
+                number_of_generations=5,
                 population_size=4,
                 number_of_parents=3,
                 parallel_jobs=2,

--- a/CI/espresso_tests/integration_tests/test_genetic_deployment.py
+++ b/CI/espresso_tests/integration_tests/test_genetic_deployment.py
@@ -1,7 +1,7 @@
 """
 Integration test for the genetic algorithm training.
 """
-import shutil
+import tempfile
 import unittest as ut
 
 import flax.linen as nn
@@ -80,88 +80,81 @@ class TestGeneticTraining(ut.TestCase):
     Test suite for the genetic training.
     """
 
-    def setUp(self):
+    def test_run(self):
         """
         Prepare the test.
         """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Exploration policy
+            exploration_policy = srl.exploration_policies.RandomExploration(
+                probability=0.0
+            )
 
-        # Exploration policy
-        exploration_policy = srl.exploration_policies.RandomExploration(probability=0.0)
+            # Sampling strategy
+            sampling_strategy = srl.sampling_strategies.GumbelDistribution()
 
-        # Sampling strategy
-        sampling_strategy = srl.sampling_strategies.GumbelDistribution()
+            # Set the task
+            task = srl.tasks.searching.GradientSensing(
+                source=np.array([500.0, 500.0, 0.0]),
+                decay_function=scale_function,
+                reward_scale_factor=10,
+                box_length=np.array([1000.0, 1000.0, 1000]),
+            )
+            observable = srl.observables.ConcentrationField(
+                source=np.array([500.0, 500.0, 0.0]),
+                decay_fn=scale_function,
+                scale_factor=10,
+                box_length=np.array([1000.0, 1000.0, 1000]),
+            )
 
-        # Set the task
-        task = srl.tasks.searching.GradientSensing(
-            source=np.array([500.0, 500.0, 0.0]),
-            decay_function=scale_function,
-            reward_scale_factor=10,
-            box_length=np.array([1000.0, 1000.0, 1000]),
-        )
-        observable = srl.observables.ConcentrationField(
-            source=np.array([500.0, 500.0, 0.0]),
-            decay_fn=scale_function,
-            scale_factor=10,
-            box_length=np.array([1000.0, 1000.0, 1000]),
-        )
+            # Define the loss model
+            loss = srl.losses.ProximalPolicyLoss(n_epochs=2)
 
-        # Define the loss model
-        loss = srl.losses.ProximalPolicyLoss(n_epochs=2)
+            network = srl.networks.FlaxModel(
+                flax_model=Network(),
+                optimizer=optax.adam(learning_rate=0.001),
+                input_shape=(1,),
+                sampling_strategy=sampling_strategy,
+                exploration_policy=exploration_policy,
+            )
 
-        network = srl.networks.FlaxModel(
-            flax_model=Network(),
-            optimizer=optax.adam(learning_rate=0.001),
-            input_shape=(1,),
-            sampling_strategy=sampling_strategy,
-            exploration_policy=exploration_policy,
-        )
+            translate = Action(force=10.0)
+            rotate_clockwise = Action(torque=np.array([0.0, 0.0, 10.0]))
+            rotate_counter_clockwise = Action(torque=np.array([0.0, 0.0, -10.0]))
+            do_nothing = Action()
 
-        translate = Action(force=10.0)
-        rotate_clockwise = Action(torque=np.array([0.0, 0.0, 10.0]))
-        rotate_counter_clockwise = Action(torque=np.array([0.0, 0.0, -10.0]))
-        do_nothing = Action()
+            actions = {
+                "RotateClockwise": rotate_clockwise,
+                "Translate": translate,
+                "RotateCounterClockwise": rotate_counter_clockwise,
+                "DoNothing": do_nothing,
+            }
 
-        actions = {
-            "RotateClockwise": rotate_clockwise,
-            "Translate": translate,
-            "RotateCounterClockwise": rotate_counter_clockwise,
-            "DoNothing": do_nothing,
-        }
+            protocol = srl.rl_protocols.ActorCritic(
+                particle_type=0,
+                network=network,
+                task=task,
+                observable=observable,
+                actions=actions,
+            )
 
-        protocol = srl.rl_protocols.ActorCritic(
-            particle_type=0,
-            network=network,
-            task=task,
-            observable=observable,
-            actions=actions,
-        )
+            rl_trainer = srl.gyms.Gym(
+                [protocol],
+                loss,
+            )
+            self.training_routine = srl.training_routines.GeneticTraining(
+                rl_trainer,
+                get_simulation_runner,
+                n_episodes=10,
+                output_directory=temp_dir,
+                episode_length=5,
+                number_of_generations=2,
+                population_size=4,
+                number_of_parents=3,
+                parallel_jobs=2,
+            )
 
-        rl_trainer = srl.gyms.Gym(
-            [protocol],
-            loss,
-        )
-        self.training_routine = srl.training_routines.GeneticTraining(
-            rl_trainer,
-            get_simulation_runner,
-            n_episodes=50,
-            episode_length=20,
-            number_of_generations=3,
-            population_size=10,
-            number_of_parents=3,
-            parallel_jobs=2,
-        )
-
-    def test_run(self):
-        """
-        Test that the code runs correctly.
-        """
-        self.training_routine.train_model()
-
-    def tearDown(self):
-        """
-        Clean up after running.
-        """
-        shutil.rmtree("genetic_algorithm")
+            self.training_routine.train_model()
 
 
 if __name__ == "__main__":

--- a/CI/espresso_tests/integration_tests/test_rl_script.py
+++ b/CI/espresso_tests/integration_tests/test_rl_script.py
@@ -118,7 +118,7 @@ class TestRLScript(ut.TestCase):
         network = srl.networks.FlaxModel(
             flax_model=acto_critic,
             optimizer=optax.adam(learning_rate=0.001),
-            input_shape=(1,),
+            input_shape=(1, 1),
             sampling_strategy=sampling_strategy,
             exploration_policy=exploration_policy,
         )

--- a/CI/espresso_tests/integration_tests/test_rl_script.py
+++ b/CI/espresso_tests/integration_tests/test_rl_script.py
@@ -119,7 +119,7 @@ class TestRLScript(ut.TestCase):
         network = srl.networks.FlaxModel(
             flax_model=acto_critic,
             optimizer=optax.adam(learning_rate=0.001),
-            input_shape=(1, 1),
+            input_shape=(1,),
             sampling_strategy=sampling_strategy,
             exploration_policy=exploration_policy,
         )

--- a/swarmrl/training_routines/ensemble_submit.py
+++ b/swarmrl/training_routines/ensemble_submit.py
@@ -74,7 +74,7 @@ class EnsembleTraining:
         if cluster is None:
             cluster = LocalCluster(
                 processes=True,
-                threads_per_worker=1,
+                threads_per_worker=2,
                 silence_logs=logging.ERROR,
                 resources={"espresso": 1},
             )

--- a/swarmrl/training_routines/ensemble_submit.py
+++ b/swarmrl/training_routines/ensemble_submit.py
@@ -57,7 +57,7 @@ class EnsembleTraining:
 
         """
         self.simulation_runner_generator = simulation_runner_generator
-        self.output_dir = output_dir
+        self.output_dir = Path(output_dir)
         self.load_path = load_path
         self.episode_length = episode_length
         self.n_episodes = n_episodes

--- a/swarmrl/training_routines/genetic_algorithm.py
+++ b/swarmrl/training_routines/genetic_algorithm.py
@@ -41,14 +41,8 @@ class GeneticTraining:
         """
         Constructor for the genetic training routine.
 
-        Parameters  data,
-                            # first_atom_range=first_atom_range,
-                            # second_atom_range=second_atom_range,
-                            correlation_time=correlation_time,
-                            data_range=data_range,
-                            )able
-            A function that will returimport numpy as onp
-            esults to.
+        Parameters
+        ----------
         n_episodes : int
             Number of episodes in each lifespan
         number_of_generations : int (default: 10)
@@ -94,7 +88,7 @@ class GeneticTraining:
         if cluster is None:
             cluster = LocalCluster(
                 processes=True,
-                threads_per_worker=1,
+                threads_per_worker=2,
                 silence_logs=logging.ERROR,
                 resources={"espresso": 1},
             )


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #41 

This PR aims to resolve the issues arising in the Dask-related training routines. On the local side, only the ensemble training had minor problems related to recent code changes. But as they had been removed for some time, this was expected. Otherwise, no issues were running the tests locally. ~~Therefore, I assume this is a problem with the available resources on the GitHub runners. To remedy this, I have made the tests smaller.~~ This was not the problem but making the tests smaller has improved the run times so I will leave it. It looks like the problem came from setting the number of threads in dask to 1. Any number great than 1 will work. 

#### Summary of additions and changes

* Fix formatting issues with ensemble training
* Put genetic training test into a `tempdir`
* Reduce the size of the tests, i.e. number of episodes, episode length and so on.

#### How to test this pull request
You can run either the genetic algorithm or ensemble training test locally, but as mentioned, this did not cause issues in the first place. I could not reproduce the problem on my machine.