### PR TITLE
PGO Debugging

### DIFF
--- a/CI/unit_tests/networks/test_flax_network.py
+++ b/CI/unit_tests/networks/test_flax_network.py
@@ -58,7 +58,6 @@ class TestFlaxNetwork:
             exploration_policy=self.exploration_policy,
         )
         input_data = np.array([[1.0, 2.0], [4.0, 5.0]])
-        print(input_data.shape)
 
         data_from_call, value_from_call = model.apply_fn(
             {"params": model.model_state.params}, input_data
@@ -70,6 +69,25 @@ class TestFlaxNetwork:
         assert value_from_call.shape == (2, 1)
         assert action_indices.shape == (2,)
         assert action_logits.shape == (2,)
+
+    def test_call_method(self):
+        """
+        Test that the call method works.
+        """
+        model = FlaxModel(
+            flax_model=self.network,
+            optimizer=optax.adam(learning_rate=0.001),
+            input_shape=(2,),
+            sampling_strategy=self.sampling_strategy,
+            exploration_policy=self.exploration_policy,
+        )
+        input_data = np.random.uniform(size=(10, 100, 2))
+
+        data_from_call, value_from_call = model(model.model_state.params, input_data)
+
+        # Check shapes
+        assert data_from_call.shape == (10, 100, 4)
+        assert value_from_call.shape == (10, 100, 1)
 
     def test_saving_and_reloading(self):
         """

--- a/CI/unit_tests/networks/test_flax_network.py
+++ b/CI/unit_tests/networks/test_flax_network.py
@@ -58,8 +58,11 @@ class TestFlaxNetwork:
             exploration_policy=self.exploration_policy,
         )
         input_data = np.array([[1.0, 2.0], [4.0, 5.0]])
+        print(input_data.shape)
 
-        data_from_call, value_from_call = model(model.model_state.params, input_data)
+        data_from_call, value_from_call = model.apply_fn(
+            {"params": model.model_state.params}, input_data
+        )
         action_indices, action_logits = model.compute_action(input_data)
 
         # Check shapes
@@ -81,8 +84,8 @@ class TestFlaxNetwork:
             exploration_policy=self.exploration_policy,
         )
         input_vector = np.array([[1.0, 2.0]])
-        pre_save_logits, pre_save_value = pre_save_model(
-            pre_save_model.model_state.params, input_vector
+        pre_save_logits, pre_save_value = pre_save_model.apply_fn(
+            {"params": pre_save_model.model_state.params}, input_vector
         )
         pre_save_model.export_model(filename="model", directory="Models")
 
@@ -97,8 +100,8 @@ class TestFlaxNetwork:
             sampling_strategy=self.sampling_strategy,
             exploration_policy=self.exploration_policy,
         )
-        post_save_logits, post_save_value = post_save_model(
-            post_save_model.model_state.params, input_vector
+        post_save_logits, post_save_value = post_save_model.apply_fn(
+            {"params": post_save_model.model_state.params}, input_vector
         )
         # Check that the logits are different
         np.testing.assert_raises(
@@ -118,8 +121,8 @@ class TestFlaxNetwork:
 
         # Load the model state
         post_save_model.restore_model_state(directory="Models", filename="model")
-        post_restore_logits, post_restore_value = post_save_model(
-            post_save_model.model_state.params, input_vector
+        post_restore_logits, post_restore_value = post_save_model.apply_fn(
+            {"params": post_save_model.model_state.params}, input_vector
         )
 
         np.testing.assert_array_equal(pre_save_logits, post_restore_logits)

--- a/swarmrl/losses/policy_gradient_loss.py
+++ b/swarmrl/losses/policy_gradient_loss.py
@@ -126,7 +126,7 @@ class PolicyGradientLoss(Loss):
         self.n_time_steps = jnp.shape(feature_data)[0]
 
         network_grad_fn = jax.value_and_grad(self._calculate_loss)
-        network_loss, network_grads = network_grad_fn(
+        _, network_grads = network_grad_fn(
             network.model_state.params,
             network=network,
             feature_data=feature_data,

--- a/swarmrl/losses/policy_gradient_loss.py
+++ b/swarmrl/losses/policy_gradient_loss.py
@@ -94,12 +94,11 @@ class PolicyGradientLoss(Loss):
         advantage = returns - predicted_values
         logger.debug(f"{advantage=}")
 
-        actor_loss = -1 * ((log_probs * advantage).sum(axis=0)).mean()
+        actor_loss = -1 * ((log_probs * advantage).sum(axis=0)).sum()
         logger.debug(f"{actor_loss=}")
 
-        critic_loss = jnp.sum(optax.huber_loss(predicted_values, returns), axis=0)
-
-        critic_loss = jnp.mean(critic_loss)
+        # Sum over time steps and average over agents.
+        critic_loss = optax.huber_loss(predicted_values, returns).sum(axis=0).sum()
 
         return actor_loss + critic_loss
 

--- a/swarmrl/losses/proximal_policy_loss.py
+++ b/swarmrl/losses/proximal_policy_loss.py
@@ -156,7 +156,7 @@ class ProximalPolicyLoss(Loss, ABC):
 
         for _ in range(self.n_epochs):
             network_grad_fn = jax.value_and_grad(self._calculate_loss)
-            network_loss, network_grad = network_grad_fn(
+            _, network_grad = network_grad_fn(
                 network.model_state.params,
                 network=network,
                 feature_data=feature_data,

--- a/swarmrl/models/ml_model.py
+++ b/swarmrl/models/ml_model.py
@@ -99,7 +99,7 @@ class MLModel(InteractionModel):
             observables[_type] = self.observables[_type].compute_observable(colloids)
             rewards[_type] = self.tasks[_type](colloids)
             action_indices[_type], log_probs[_type] = self.models[_type].compute_action(
-                observables=observables[_type], explore_mode=explore_mode
+                observables=observables[_type]
             )
             chosen_actions = np.take(
                 list(self.actions[_type].values()), action_indices[_type], axis=-1

--- a/swarmrl/networks/flax_network.py
+++ b/swarmrl/networks/flax_network.py
@@ -66,8 +66,10 @@ class FlaxModel(Network, ABC):
             rng_key = onp.random.randint(0, 1027465782564)
         self.sampling_strategy = sampling_strategy
         self.model = flax_model
-        self.apply_fn = jax.vmap(self.model.apply, in_axes=(None, 0))  # Map over agents
-        self.batch_apply_fn = jax.vmap(self.apply_fn, in_axes=(None, 0))
+        self.apply_fn = jax.jit(
+            jax.vmap(self.model.apply, in_axes=(None, 0))
+        )  # Map over agents
+        self.batch_apply_fn = jax.jit(jax.vmap(self.apply_fn, in_axes=(None, 0)))
         self.input_shape = input_shape
         self.model_state = None
 


### PR DESCRIPTION
We have noticed after the recent model API change that the simple policy gradient updates are struggling to train. I am going through each stage and cleaning up the data transport to make this easier. A collection of my changes are below:

* Standardized `vmap` calls on model input. Now, users should provide only the observable shape to the network and not the batch dimension. During action calls this has a single vmap over agents and during training it has two vmaps over agents and time steps.
* Standardized the operations in losses. We now sum over time and agents. I fixed the code comments and shortened it to `.sum()` operations.

The problem with PGO was simply the reward magnitude being too small. I have successfully trained chemotaxis in 200 steps.