### PR TITLE
semi episodic file writing fixed.

### DIFF
--- a/CI/espresso_tests/integration_tests/test_rl_trainers.py
+++ b/CI/espresso_tests/integration_tests/test_rl_trainers.py
@@ -4,6 +4,7 @@ import unittest as ut
 
 import espressomd
 import flax.linen as nn
+import h5py
 import numpy as np
 import optax
 import pint
@@ -351,6 +352,63 @@ class EspressoTestRLTrainers(ut.TestCase):
 
             dumped_files = glob.glob(f"{temp_dir}/episodic/*")
             assert len(dumped_files) == 5
+
+    def test_semi_episodic_data_writing(self):
+        """
+        Test the episodic training for set episode length.
+
+        The training should dump 10 trajectories.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+
+            def get_engine(system, cycle_index=0):
+                """
+                Get the engine.
+                """
+
+                seed = np.random.randint(89675392)
+                system_runner = srl.espresso.EspressoMD(
+                    md_params=self.md_params,
+                    n_dims=2,
+                    seed=seed,
+                    out_folder=f"{temp_dir}/episodic/data_writing",
+                    system=self.system,
+                    write_chunk_size=10,
+                    h5_group_tag=cycle_index,
+                )
+
+                coll_type = 0
+                system_runner.add_colloids(
+                    5,
+                    self.ureg.Quantity(2.14, "micrometer"),
+                    self.ureg.Quantity(np.array([500, 500, 0]), "micrometer"),
+                    self.ureg.Quantity(400, "micrometer"),
+                    type_colloid=coll_type,
+                )
+
+                return system_runner
+
+            # Define the force model.
+            rl_trainer = srl.trainers.EpisodicTrainer(
+                [self.agent],
+            )
+            rl_trainer.perform_rl_training(
+                get_engine=get_engine,
+                n_episodes=10,
+                system=self.system,
+                episode_length=10,
+                save_episodic_data=True,
+            )
+
+            with h5py.File(
+                f"{temp_dir}/episodic/data_writing/trajectory.hdf5", "r"
+            ) as file:
+                keys = list(file.keys())
+
+            assert len(keys) == 10
+            assert keys == ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+            dumped_files = glob.glob(f"{temp_dir}/episodic/*")
+            assert len(dumped_files) == 1
 
 
 if __name__ == "__main__":

--- a/swarmrl/trainers/episodic_trainer.py
+++ b/swarmrl/trainers/episodic_trainer.py
@@ -31,6 +31,7 @@ class EpisodicTrainer(Trainer):
         episode_length: int,
         reset_frequency: int = 1,
         load_bar: bool = True,
+        save_episodic_data: bool = False,
     ):
         """
         Perform the RL training.
@@ -49,6 +50,9 @@ class EpisodicTrainer(Trainer):
                 After how many episodes is the simulation reset.
         load_bar : bool (default=True)
                 If true, show a progress bar.
+        save_episodic_data : bool (default=False)
+                If true, save the episode data. If false, the data is of the
+                last episode is overwritten by the new data.
 
         Notes
         -----
@@ -59,7 +63,7 @@ class EpisodicTrainer(Trainer):
         rewards = [0.0]
         current_reward = 0.0
         force_fn = self.initialize_training()
-
+        cycle_index = 0
         progress = Progress(
             "Episode: {task.fields[Episode]}",
             BarColumn(),
@@ -79,9 +83,22 @@ class EpisodicTrainer(Trainer):
             )
             for episode in range(n_episodes):
                 # Check if the system should be reset.
-                if episode % reset_frequency == 0 or killed:
+                if episode % reset_frequency == 0 and reset_frequency > 0 or killed:
                     self.engine = None
-                    self.engine = get_engine(system)
+                    if save_episodic_data:
+                        try:
+                            self.engine = get_engine(system, f"{cycle_index}")
+                            cycle_index += 1
+                        except TypeError:
+                            raise ValueError(
+                                "The system runner does not support episodic data"
+                                " saving. Your get_engine function should take a system"
+                                " and a str(cycle_index) as arguments. The cycle_index"
+                                " is passed to the EsperessoMD engine as"
+                                " 'h5_group_tag'."
+                            )
+                    else:
+                        self.engine = get_engine(system)
 
                     # Initialize the tasks and observables.
                     for agent in self.agents.values():


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #

#### Summary of additions and changes

* the trajectories of the simulations are now all saved to the same file 
* for each cycle (all episodes between two resets) there is a new group in the hdf5 database
* for none episodic or the case that one does not look to that data, the group is still called "colloids" 
* 

#### How to test this pull request

```

```