### PR TITLE
Fix error for multi-active-species

### DIFF
--- a/CI/unit_tests/agents/test_agent_from_trajectory.py
+++ b/CI/unit_tests/agents/test_agent_from_trajectory.py
@@ -42,8 +42,9 @@ class TestAgentFromTrajectory(ut.TestCase):
             pos=np.array([1.0, 0, 0]), director=np.array([1, 0, 0]), id=2, type=0
         )
         actions = self.agent_force_function.calc_action([coll0, coll1])
+
+        assert len(actions) == 1
         self.assertGreater(actions[0].force, 0)
-        self.assertEqual(actions[1].force, 0)
 
     def test_force_trajectory(self):
         coll0 = Colloid(
@@ -53,8 +54,8 @@ class TestAgentFromTrajectory(ut.TestCase):
             pos=np.array([1.0, 0, 0]), director=np.array([1, 0, 0]), id=2, type=0
         )
         actions = self.agent_trajectory.calc_action([coll0, coll1])
+        assert len(actions) == 1
         self.assertGreater(actions[0].force, 1)
-        self.assertEqual(actions[1].force, 0)
 
 
 if __name__ == "__main__":

--- a/swarmrl/agents/agent.py
+++ b/swarmrl/agents/agent.py
@@ -38,7 +38,8 @@ class Agent:
         Returns
         -------
         actions: typing.List[Action]
-                Return the action the colloid should take.
+                Return the action the colloid should take. Only return actions for the
+                colloid types that the agent should act on.
         kill_switch : bool
                 Flag capable of ending simulation.
         """

--- a/swarmrl/agents/agent_from_trajectory.py
+++ b/swarmrl/agents/agent_from_trajectory.py
@@ -101,7 +101,6 @@ class AgentFromTrajectory(ClassicalAgent):
 
         for colloid in colloids:
             if colloid.type not in self.acts_on_types:
-                actions.append(Action())
                 continue
 
             if self.force_function is not None:

--- a/swarmrl/agents/lymburn_model.py
+++ b/swarmrl/agents/lymburn_model.py
@@ -12,6 +12,7 @@ class Lymburn(ClassicalAgent):
         detection_radius_position_pred=np.inf,
         home_pos=np.array([500, 500, 0]),
         agent_speed=10,
+        predator_type: int = 1,
     ):
         """
         Parameters
@@ -29,12 +30,15 @@ class Lymburn(ClassicalAgent):
             Position of the home
         agent_speed : float
             Speed of the colloids (used for the friction force)
+        predator_type : int
+            Type of the predator colloids.
         """
         self.force_params = force_params
         self.detection_radius_position_colls = detection_radius_position_colls
         # implies r_align=r_repulsion
         self.detection_radius_position_pred = detection_radius_position_pred
         self.home_pos = home_pos
+        self.predator_type = predator_type
         self.agent_speed = agent_speed
 
     def update_force_params(self, K_a=None, K_r=None, K_h=None, K_f=None, K_p=None):
@@ -49,11 +53,18 @@ class Lymburn(ClassicalAgent):
     def calc_action(self, colloids):
         actions = []
         for colloid in colloids:
-            other_colls = [c for c in colloids if c is not colloid and not c.type == 1]
+            if colloid.type == self.predator_type:
+                continue
+
+            other_colls = [
+                c
+                for c in colloids
+                if c is not colloid and not c.type == self.predator_type
+            ]
             colls_in_vision = get_colloids_in_vision(
                 colloid, other_colls, vision_radius=self.detection_radius_position_colls
             )
-            predator = [p for p in colloids if p.type == 1]
+            predator = [p for p in colloids if p.type == self.predator_type]
             # only one predator in the simulation
             pred_in_vision = get_colloids_in_vision(
                 colloid, predator, vision_radius=self.detection_radius_position_pred

--- a/swarmrl/force_functions/force_fn.py
+++ b/swarmrl/force_functions/force_fn.py
@@ -79,7 +79,7 @@ class ForceFunction:
             for colloid in colloids:
                 if str(colloid.type) == agent:
                     actions[colloid.id] = computed_actions[count]
-                    count += 1
+                count += 1
 
         self.kill_switch = any(switches)
 

--- a/swarmrl/force_functions/force_fn.py
+++ b/swarmrl/force_functions/force_fn.py
@@ -79,7 +79,7 @@ class ForceFunction:
             for colloid in colloids:
                 if str(colloid.type) == agent:
                     actions[colloid.id] = computed_actions[count]
-                count += 1
+                    count += 1
 
         self.kill_switch = any(switches)
 


### PR DESCRIPTION
~~There was a hidden bug in our training procedure for multiple active species. This was due to a counter being under an if statement when it should have always been counting. Is now fixed.~~

This was not a hidden bug, it was doing as it was supposed to. However, I never documented the correct return structure of an agent which was then ambiguous. Agents should only return actions for the number of colloids they control. This was never specified and thus, several agents returned the wrong shape of data, leading to the problem that highlighted this error in and experiment. I have no corrected these agents and commented in the parent class. However, this could be made stricter.