### PR TITLE
Add flax dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ distributed>=2024.4.2
 numpy>=1.26.4
 jax>=0.4.26
 jaxlib>=0.4.26
+flax>=0.8.1


### PR DESCRIPTION
#### Summary of additions and changes

* Added `flax` to `requirements.txt`. 
Fixes the associated `ModuleNotFoundError`.

#### How to test this pull request

1. Install the package locally
```
pip install .
```
2. Start python and try importing
```
python -c "import swarmrl; print('swarmrl imported successfully')"
```