### PR TITLE
Refactor HDF5 trajectory storage, add agent data saving

### DIFF
--- a/.github/workflows/espresso.yml
+++ b/.github/workflows/espresso.yml
@@ -49,6 +49,10 @@ jobs:
 
       - name: Run test suite
         run: |
+          # Ensure MODULEPATH contains the ESPResSo zen2 modules before restore.
+          # This mirrors the `module use` used in the Install step so
+          # `module restore espresso` can find the saved module.
+          test "${RUNNER_ARCH}" = "X64" && module use /cvmfs/dev.eessi.io/espresso/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all
           module restore espresso
           export NUM_PROC=$(nproc)
           export OMP_PROC_BIND=false 

--- a/CI/espresso_tests/integration_tests/test_rl_trainers.py
+++ b/CI/espresso_tests/integration_tests/test_rl_trainers.py
@@ -379,6 +379,7 @@ class EspressoTestRLTrainers(ut.TestCase):
                     system=self.system,
                     write_chunk_size=10,
                     h5_group_tag=cycle_index,
+                    fail_if_trajectory_file_exists=False,
                 )
 
                 coll_type = 0

--- a/CI/espresso_tests/integration_tests/test_rl_trainers.py
+++ b/CI/espresso_tests/integration_tests/test_rl_trainers.py
@@ -51,7 +51,7 @@ class KillTask(srl.tasks.Task):
     Dummy task for the tests.
 
     This task will turn on the killswitch after
-    4 episodes.
+    15 episodes.
     """
 
     i: int = 0

--- a/CI/espresso_tests/integration_tests/test_rl_trainers.py
+++ b/CI/espresso_tests/integration_tests/test_rl_trainers.py
@@ -428,7 +428,7 @@ class EspressoTestRLTrainers(ut.TestCase):
                     system=self.system,
                     write_chunk_size=10,
                     h5_group_tag=cycle_index,
-                    fail_if_trajectory_file_exists=False,
+                    allow_existing_trajectory_file=True,
                 )
 
                 coll_type = 0

--- a/CI/espresso_tests/integration_tests/test_rl_trainers.py
+++ b/CI/espresso_tests/integration_tests/test_rl_trainers.py
@@ -51,7 +51,7 @@ class KillTask(srl.tasks.Task):
     Dummy task for the tests.
 
     This task will turn on the killswitch after
-    15 episodes.
+    4 episodes.
     """
 
     i: int = 0
@@ -181,7 +181,7 @@ class EspressoTestRLTrainers(ut.TestCase):
                 self.ureg.Quantity(400, "micrometer"),
                 type_colloid=0,
             )
-            # We need a custom protoc0l for this test.
+            # We need a custom protocol for this test.
             agent = srl.agents.ActorCriticAgent(
                 particle_type=0,
                 network=self.network,
@@ -281,7 +281,7 @@ class EspressoTestRLTrainers(ut.TestCase):
 
                 return system_runner
 
-            # We need a custom protoc0l for this test.
+            # We need a custom protocol for this test.
             agent = srl.agents.ActorCriticAgent(
                 particle_type=0,
                 network=self.network,

--- a/CI/unit_tests/agents/test_agent_storage_hooks.py
+++ b/CI/unit_tests/agents/test_agent_storage_hooks.py
@@ -1,0 +1,33 @@
+"""Tests for generic storage hooks on the Agent base class."""
+
+from swarmrl.agents.agent import Agent
+
+
+class _DummyAgent(Agent):
+    def calc_action(self, colloids):
+        return []
+
+
+class _DummyStorage:
+    def __init__(self):
+        self.writes = []
+
+    def write(self, trajectory):
+        self.writes.append(trajectory)
+
+
+class TestAgentStorageHooks:
+    def test_storage_hooks_are_noop_without_backend(self):
+        agent = _DummyAgent()
+
+        agent.persist_trajectory({"step": 1})
+
+    def test_storage_hooks_delegate_to_backend(self):
+        agent = _DummyAgent()
+        storage = _DummyStorage()
+        trajectory_data = {"step": 3}
+
+        agent.trajectory_storage = storage
+        agent.persist_trajectory(trajectory_data)
+
+        assert storage.writes == [trajectory_data]

--- a/CI/unit_tests/agents/test_agent_storage_hooks.py
+++ b/CI/unit_tests/agents/test_agent_storage_hooks.py
@@ -11,9 +11,13 @@ class _DummyAgent(Agent):
 class _DummyStorage:
     def __init__(self):
         self.writes = []
+        self.finalize_calls = 0
 
     def write(self, trajectory):
         self.writes.append(trajectory)
+
+    def finalize(self):
+        self.finalize_calls += 1
 
 
 class TestAgentStorageHooks:
@@ -31,3 +35,17 @@ class TestAgentStorageHooks:
         agent.persist_trajectory(trajectory_data)
 
         assert storage.writes == [trajectory_data]
+
+    def test_finalize_storage_hooks_are_noop_without_backend(self):
+        agent = _DummyAgent()
+
+        agent.finalize_trajectory_storage()
+
+    def test_finalize_storage_hooks_delegate_to_backend(self):
+        agent = _DummyAgent()
+        storage = _DummyStorage()
+
+        agent.trajectory_storage = storage
+        agent.finalize_trajectory_storage()
+
+        assert storage.finalize_calls == 1

--- a/CI/unit_tests/agents/test_agent_storage_hooks.py
+++ b/CI/unit_tests/agents/test_agent_storage_hooks.py
@@ -36,16 +36,16 @@ class TestAgentStorageHooks:
 
         assert storage.writes == [trajectory_data]
 
-    def test_finalize_storage_hooks_are_noop_without_backend(self):
+    def test_finalize_hooks_are_noop_without_backend(self):
         agent = _DummyAgent()
 
-        agent.finalize_trajectory_storage()
+        agent.finalize()
 
-    def test_finalize_storage_hooks_delegate_to_backend(self):
+    def test_finalize_hooks_delegate_to_backend(self):
         agent = _DummyAgent()
         storage = _DummyStorage()
 
         agent.trajectory_storage = storage
-        agent.finalize_trajectory_storage()
+        agent.finalize()
 
         assert storage.finalize_calls == 1

--- a/CI/unit_tests/trainers/test_trainer_storage_hooks.py
+++ b/CI/unit_tests/trainers/test_trainer_storage_hooks.py
@@ -1,0 +1,27 @@
+"""Tests for trainer-level storage lifecycle hooks."""
+
+from swarmrl.agents.agent import Agent
+from swarmrl.trainers.trainer import Trainer
+
+
+class _DummyAgent(Agent):
+    def __init__(self, particle_type):
+        self.particle_type = particle_type
+        self.finalize_calls = 0
+
+    def calc_action(self, colloids):
+        return []
+
+    def finalize_trajectory_storage(self):
+        self.finalize_calls += 1
+
+
+def test_trainer_finalize_agents_delegates_to_agents():
+    agent_0 = _DummyAgent(particle_type=0)
+    agent_1 = _DummyAgent(particle_type=1)
+    trainer = Trainer([agent_0, agent_1])
+
+    trainer.finalize_agents()
+
+    assert agent_0.finalize_calls == 1
+    assert agent_1.finalize_calls == 1

--- a/CI/unit_tests/trainers/test_trainer_storage_hooks.py
+++ b/CI/unit_tests/trainers/test_trainer_storage_hooks.py
@@ -12,7 +12,7 @@ class _DummyAgent(Agent):
     def calc_action(self, colloids):
         return []
 
-    def finalize_trajectory_storage(self):
+    def finalize(self):
         self.finalize_calls += 1
 
 

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -1,0 +1,158 @@
+"""Tests for storage writer behavior."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import numpy.testing as npt
+
+from swarmrl.utils.colloid_utils import TrajectoryInformation
+from swarmrl.utils.storage_utils import (
+    AgentTrajectoryStorage,
+    SimulationTrajectoryStorage,
+)
+
+
+def _make_agent_trajectory(
+    particle_type: int,
+    episode_length: int,
+    n_colloids: int,
+    base_value: float,
+) -> TrajectoryInformation:
+    trajectory = TrajectoryInformation(particle_type=particle_type)
+    trajectory.features = np.full(
+        (episode_length, n_colloids, 1), base_value, dtype=np.float32
+    )
+    trajectory.actions = np.full(
+        (episode_length, n_colloids), int(base_value), dtype=int
+    )
+    trajectory.log_probs = np.full(
+        (episode_length, n_colloids), base_value + 0.1, dtype=float
+    )
+    trajectory.rewards = np.full(
+        (episode_length, n_colloids), base_value + 0.2, dtype=float
+    )
+    return trajectory
+
+
+def _make_sim_timestep(n_colloids: int, time_value: float) -> dict:
+    return {
+        "Times": np.array([time_value], dtype=float)[:, np.newaxis],
+        "Ids": np.arange(n_colloids, dtype=int)[:, np.newaxis],
+        "Types": np.zeros((n_colloids, 1), dtype=int),
+        "Unwrapped_Positions": np.full((n_colloids, 3), time_value, dtype=float),
+        "Velocities": np.full((n_colloids, 3), time_value + 1.0, dtype=float),
+        "Directors": np.full((n_colloids, 3), time_value + 2.0, dtype=float),
+    }
+
+
+class TestStorageWriters:
+    def test_agent_storage_initializes_and_writes_first_sample(self, tmp_path: Path):
+        storage = AgentTrajectoryStorage(particle_type=2, out_folder=str(tmp_path))
+        trajectory = _make_agent_trajectory(
+            2,
+            episode_length=4,
+            n_colloids=3,
+            base_value=1.0,
+        )
+
+        storage.write(trajectory)
+
+        file_path = tmp_path / "agent_data_2.hdf5"
+        assert file_path.exists()
+        assert storage.is_initialized
+        assert storage._write_idx == 1
+
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            group = h5_file["Agent_2"]
+            assert group["features"].shape == (1, 4, 3, 1)
+            assert group["actions"].shape == (1, 4, 3)
+            assert group["log_probs"].shape == (1, 4, 3)
+            assert group["rewards"].shape == (1, 4, 3)
+            npt.assert_allclose(group["features"][0], trajectory.features)
+
+    def test_agent_storage_appends_without_overwriting(self, tmp_path: Path):
+        storage = AgentTrajectoryStorage(particle_type=0, out_folder=str(tmp_path))
+        first = _make_agent_trajectory(
+            0, episode_length=2, n_colloids=2, base_value=3.0
+        )
+        second = _make_agent_trajectory(
+            0, episode_length=2, n_colloids=2, base_value=7.0
+        )
+
+        storage.write(first)
+        storage.write(second)
+
+        file_path = tmp_path / "agent_data_0.hdf5"
+        assert storage._write_idx == 2
+
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            dataset = h5_file["Agent_0"]["features"]
+            assert dataset.shape == (2, 2, 2, 1)
+            npt.assert_allclose(dataset[0], first.features)
+            npt.assert_allclose(dataset[1], second.features)
+
+    def test_sim_storage_batch_write_appends(self, tmp_path: Path):
+        storage = SimulationTrajectoryStorage(
+            out_folder=str(tmp_path),
+            h5_group_tag="traj_group",
+        )
+        first = _make_sim_timestep(n_colloids=3, time_value=1.0)
+        storage.write(first)
+
+        batch = {
+            "Times": [
+                _make_sim_timestep(3, 2.0)["Times"],
+                _make_sim_timestep(3, 3.0)["Times"],
+            ],
+            "Ids": [
+                _make_sim_timestep(3, 2.0)["Ids"],
+                _make_sim_timestep(3, 3.0)["Ids"],
+            ],
+            "Types": [
+                _make_sim_timestep(3, 2.0)["Types"],
+                _make_sim_timestep(3, 3.0)["Types"],
+            ],
+            "Unwrapped_Positions": [
+                _make_sim_timestep(3, 2.0)["Unwrapped_Positions"],
+                _make_sim_timestep(3, 3.0)["Unwrapped_Positions"],
+            ],
+            "Velocities": [
+                _make_sim_timestep(3, 2.0)["Velocities"],
+                _make_sim_timestep(3, 3.0)["Velocities"],
+            ],
+            "Directors": [
+                _make_sim_timestep(3, 2.0)["Directors"],
+                _make_sim_timestep(3, 3.0)["Directors"],
+            ],
+        }
+
+        storage.write_accumulated_batch(batch)
+
+        file_path = tmp_path / "trajectory.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            times = h5_file["traj_group"]["Times"]
+            assert times.shape[0] == 3
+            assert np.isclose(times[0, 0, 0], 1.0)
+            assert np.isclose(times[1, 0, 0], 2.0)
+            assert np.isclose(times[2, 0, 0], 3.0)
+
+    def test_empty_batch_is_noop(self, tmp_path: Path):
+        storage = SimulationTrajectoryStorage(
+            out_folder=str(tmp_path),
+            h5_group_tag="traj_group",
+        )
+        storage.write(_make_sim_timestep(n_colloids=2, time_value=1.0))
+        idx_before = storage._write_idx
+
+        empty_batch = {
+            "Times": [],
+            "Ids": [],
+            "Types": [],
+            "Unwrapped_Positions": [],
+            "Velocities": [],
+            "Directors": [],
+        }
+        storage.write_accumulated_batch(empty_batch)
+
+        assert storage._write_idx == idx_before

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -190,11 +190,11 @@ class TestStorageWriters:
             assert "log_probs" not in group
             assert "features" not in group
 
-    def test_agent_storage_persists_killed_and_particle_type(self, tmp_path: Path):
+    def test_agent_storage_persists_killed(self, tmp_path: Path):
         storage = AgentTrajectoryStorage(
             particle_type=4,
             out_folder=str(tmp_path),
-            stored_attributes=["killed", "particle_type"],
+            stored_attributes=["killed"],
         )
         trajectory = _make_agent_trajectory(
             4,
@@ -209,9 +209,7 @@ class TestStorageWriters:
         with h5py.File(file_path.as_posix(), "r") as h5_file:
             group = h5_file["Agent_4"]
             assert group["killed"].shape == (1, 1)
-            assert group["particle_type"].shape == (1, 1)
             assert bool(group["killed"][0, 0]) is True
-            assert int(group["particle_type"][0, 0]) == 4
 
     def test_sim_storage_batch_write_appends(self, tmp_path: Path):
         storage = SimulationTrajectoryStorage(

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -67,6 +67,30 @@ def _make_sim_timestep(n_colloids: int, time_value: float) -> dict:
 
 
 class TestStorageWriters:
+    def test_sim_storage_fails_if_file_exists_by_default(self, tmp_path: Path):
+        first_storage = SimulationTrajectoryStorage(out_folder=str(tmp_path))
+        first_storage.write(_make_sim_timestep(n_colloids=2, time_value=1.0))
+
+        second_storage = SimulationTrajectoryStorage(out_folder=str(tmp_path))
+        with pytest.raises(FileExistsError, match="Refusing to write"):
+            second_storage.write(_make_sim_timestep(n_colloids=2, time_value=2.0))
+
+    def test_sim_storage_allows_existing_file_if_opted_in(self, tmp_path: Path):
+        first_storage = SimulationTrajectoryStorage(out_folder=str(tmp_path))
+        first_storage.write(_make_sim_timestep(n_colloids=2, time_value=1.0))
+
+        second_storage = SimulationTrajectoryStorage(
+            out_folder=str(tmp_path),
+            fail_if_exists=False,
+        )
+        second_storage.write(_make_sim_timestep(n_colloids=2, time_value=2.0))
+
+        file_path = tmp_path / "trajectory.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            times = h5_file["colloids"]["Times"]
+            assert times.shape[0] == 1
+            assert np.isclose(times[0, 0, 0], 2.0)
+
     def test_agent_storage_fails_if_file_exists_by_default(self, tmp_path: Path):
         first_storage = AgentTrajectoryStorage(
             particle_type=7,

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from swarmrl.utils.colloid_utils import TrajectoryInformation
 from swarmrl.utils.storage_utils import (
@@ -32,6 +33,25 @@ def _make_agent_trajectory(
     trajectory.rewards = np.full(
         (episode_length, n_colloids), base_value + 0.2, dtype=float
     )
+    trajectory.killed = bool(base_value > 5.0)
+    return trajectory
+
+
+def _make_agent_trajectory_vector_features(
+    particle_type: int,
+    episode_length: int,
+    n_colloids: int,
+    feature_shape: tuple,
+    base_value: float,
+) -> TrajectoryInformation:
+    trajectory = _make_agent_trajectory(
+        particle_type=particle_type,
+        episode_length=episode_length,
+        n_colloids=n_colloids,
+        base_value=base_value,
+    )
+    full_shape = (episode_length, n_colloids, *feature_shape)
+    trajectory.features = np.full(full_shape, base_value, dtype=np.float32)
     return trajectory
 
 
@@ -47,7 +67,31 @@ def _make_sim_timestep(n_colloids: int, time_value: float) -> dict:
 
 
 class TestStorageWriters:
-    def test_agent_storage_initializes_and_writes_first_sample(self, tmp_path: Path):
+    def test_agent_storage_rejects_unknown_stored_field(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Unknown stored_fields"):
+            AgentTrajectoryStorage(
+                particle_type=1,
+                out_folder=str(tmp_path),
+                stored_fields=["actions", "foo"],
+            )
+
+    def test_agent_storage_rejects_empty_stored_fields(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="at least one field"):
+            AgentTrajectoryStorage(
+                particle_type=1,
+                out_folder=str(tmp_path),
+                stored_fields=[],
+            )
+
+    def test_agent_storage_rejects_non_iterable_stored_fields(self, tmp_path: Path):
+        with pytest.raises(TypeError, match="list, tuple, or set"):
+            AgentTrajectoryStorage(
+                particle_type=1,
+                out_folder=str(tmp_path),
+                stored_fields="actions",
+            )
+
+    def test_agent_storage_default_skips_features(self, tmp_path: Path):
         storage = AgentTrajectoryStorage(particle_type=2, out_folder=str(tmp_path))
         trajectory = _make_agent_trajectory(
             2,
@@ -65,14 +109,17 @@ class TestStorageWriters:
 
         with h5py.File(file_path.as_posix(), "r") as h5_file:
             group = h5_file["Agent_2"]
-            assert group["features"].shape == (1, 4, 3, 1)
             assert group["actions"].shape == (1, 4, 3)
-            assert group["log_probs"].shape == (1, 4, 3)
             assert group["rewards"].shape == (1, 4, 3)
-            npt.assert_allclose(group["features"][0], trajectory.features)
+            assert "log_probs" not in group
+            assert "features" not in group
 
     def test_agent_storage_appends_without_overwriting(self, tmp_path: Path):
-        storage = AgentTrajectoryStorage(particle_type=0, out_folder=str(tmp_path))
+        storage = AgentTrajectoryStorage(
+            particle_type=0,
+            out_folder=str(tmp_path),
+            preset="verbose",
+        )
         first = _make_agent_trajectory(
             0, episode_length=2, n_colloids=2, base_value=3.0
         )
@@ -91,6 +138,77 @@ class TestStorageWriters:
             assert dataset.shape == (2, 2, 2, 1)
             npt.assert_allclose(dataset[0], first.features)
             npt.assert_allclose(dataset[1], second.features)
+
+    def test_agent_storage_supports_vector_features_in_verbose_mode(
+        self,
+        tmp_path: Path,
+    ):
+        storage = AgentTrajectoryStorage(
+            particle_type=3,
+            out_folder=str(tmp_path),
+            preset="verbose",
+        )
+        trajectory = _make_agent_trajectory_vector_features(
+            particle_type=3,
+            episode_length=5,
+            n_colloids=4,
+            feature_shape=(6,),
+            base_value=2.0,
+        )
+
+        storage.write(trajectory)
+
+        file_path = tmp_path / "agent_data_3.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            feature_dataset = h5_file["Agent_3"]["features"]
+            assert feature_dataset.shape == (1, 5, 4, 6)
+            npt.assert_allclose(feature_dataset[0], trajectory.features)
+
+    def test_agent_storage_custom_fields_whitelist(self, tmp_path: Path):
+        storage = AgentTrajectoryStorage(
+            particle_type=4,
+            out_folder=str(tmp_path),
+            stored_fields=["actions", "rewards"],
+        )
+        trajectory = _make_agent_trajectory(
+            4,
+            episode_length=3,
+            n_colloids=2,
+            base_value=5.0,
+        )
+
+        storage.write(trajectory)
+
+        file_path = tmp_path / "agent_data_4.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            group = h5_file["Agent_4"]
+            assert "actions" in group
+            assert "rewards" in group
+            assert "log_probs" not in group
+            assert "features" not in group
+
+    def test_agent_storage_persists_killed_and_particle_type(self, tmp_path: Path):
+        storage = AgentTrajectoryStorage(
+            particle_type=4,
+            out_folder=str(tmp_path),
+            stored_fields=["killed", "particle_type"],
+        )
+        trajectory = _make_agent_trajectory(
+            4,
+            episode_length=3,
+            n_colloids=2,
+            base_value=6.0,
+        )
+
+        storage.write(trajectory)
+
+        file_path = tmp_path / "agent_data_4.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            group = h5_file["Agent_4"]
+            assert group["killed"].shape == (1, 1)
+            assert group["particle_type"].shape == (1, 1)
+            assert bool(group["killed"][0, 0]) is True
+            assert int(group["particle_type"][0, 0]) == 4
 
     def test_sim_storage_batch_write_appends(self, tmp_path: Path):
         storage = SimulationTrajectoryStorage(

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -67,28 +67,31 @@ def _make_sim_timestep(n_colloids: int, time_value: float) -> dict:
 
 
 class TestStorageWriters:
-    def test_agent_storage_rejects_unknown_stored_field(self, tmp_path: Path):
-        with pytest.raises(ValueError, match="Unknown stored_fields"):
+    def test_agent_storage_rejects_unknown_stored_attribute(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Unknown stored_attributes"):
             AgentTrajectoryStorage(
                 particle_type=1,
                 out_folder=str(tmp_path),
-                stored_fields=["actions", "foo"],
+                stored_attributes=["actions", "foo"],
             )
 
-    def test_agent_storage_rejects_empty_stored_fields(self, tmp_path: Path):
-        with pytest.raises(ValueError, match="at least one field"):
+    def test_agent_storage_rejects_empty_stored_attributes(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="at least one attribute"):
             AgentTrajectoryStorage(
                 particle_type=1,
                 out_folder=str(tmp_path),
-                stored_fields=[],
+                stored_attributes=[],
             )
 
-    def test_agent_storage_rejects_non_iterable_stored_fields(self, tmp_path: Path):
+    def test_agent_storage_rejects_non_iterable_stored_attributes(
+        self,
+        tmp_path: Path,
+    ):
         with pytest.raises(TypeError, match="list, tuple, or set"):
             AgentTrajectoryStorage(
                 particle_type=1,
                 out_folder=str(tmp_path),
-                stored_fields="actions",
+                stored_attributes="actions",
             )
 
     def test_agent_storage_default_skips_features(self, tmp_path: Path):
@@ -168,7 +171,7 @@ class TestStorageWriters:
         storage = AgentTrajectoryStorage(
             particle_type=4,
             out_folder=str(tmp_path),
-            stored_fields=["actions", "rewards"],
+            stored_attributes=["actions", "rewards"],
         )
         trajectory = _make_agent_trajectory(
             4,
@@ -191,7 +194,7 @@ class TestStorageWriters:
         storage = AgentTrajectoryStorage(
             particle_type=4,
             out_folder=str(tmp_path),
-            stored_fields=["killed", "particle_type"],
+            stored_attributes=["killed", "particle_type"],
         )
         trajectory = _make_agent_trajectory(
             4,

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -67,6 +67,59 @@ def _make_sim_timestep(n_colloids: int, time_value: float) -> dict:
 
 
 class TestStorageWriters:
+    def test_agent_storage_fails_if_file_exists_by_default(self, tmp_path: Path):
+        first_storage = AgentTrajectoryStorage(
+            particle_type=7,
+            out_folder=str(tmp_path),
+        )
+        trajectory = _make_agent_trajectory(
+            7,
+            episode_length=2,
+            n_colloids=2,
+            base_value=1.0,
+        )
+        first_storage.write(trajectory)
+
+        second_storage = AgentTrajectoryStorage(
+            particle_type=7,
+            out_folder=str(tmp_path),
+        )
+        with pytest.raises(FileExistsError, match="Refusing to write"):
+            second_storage.write(trajectory)
+
+    def test_agent_storage_allows_existing_file_if_opted_in(self, tmp_path: Path):
+        first_storage = AgentTrajectoryStorage(
+            particle_type=8,
+            out_folder=str(tmp_path),
+        )
+        first_storage.write(
+            _make_agent_trajectory(
+                8,
+                episode_length=2,
+                n_colloids=2,
+                base_value=1.0,
+            )
+        )
+
+        overwrite_storage = AgentTrajectoryStorage(
+            particle_type=8,
+            out_folder=str(tmp_path),
+            fail_if_exists=False,
+        )
+        overwrite_storage.write(
+            _make_agent_trajectory(
+                8,
+                episode_length=2,
+                n_colloids=2,
+                base_value=9.0,
+            )
+        )
+
+        file_path = tmp_path / "agent_data_8.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            dataset = h5_file["Agent_8"]["actions"]
+            assert int(dataset[0, 0, 0]) == 9
+
     def test_agent_storage_rejects_unknown_stored_attribute(self, tmp_path: Path):
         with pytest.raises(ValueError, match="Unknown stored_attributes"):
             AgentTrajectoryStorage(

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -268,7 +268,7 @@ class TestStorageWriters:
             npt.assert_allclose(dataset[0], first.features)
             npt.assert_allclose(dataset[1], second.features)
 
-    def test_agent_storage_flush_writes_partial_chunk(self, tmp_path: Path):
+    def test_agent_storage_finalize_writes_partial_chunk(self, tmp_path: Path):
         storage = AgentTrajectoryStorage(
             particle_type=0,
             out_folder=str(tmp_path),
@@ -280,7 +280,7 @@ class TestStorageWriters:
         )
 
         storage.write(trajectory)
-        storage.flush()
+        storage.finalize()
 
         file_path = tmp_path / "agent_data_0.hdf5"
         assert storage._write_idx == 1

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -219,6 +219,54 @@ class TestStorageWriters:
             npt.assert_allclose(dataset[0], first.features)
             npt.assert_allclose(dataset[1], second.features)
 
+    def test_agent_storage_respects_write_chunk_size(self, tmp_path: Path):
+        storage = AgentTrajectoryStorage(
+            particle_type=0,
+            out_folder=str(tmp_path),
+            preset="verbose",
+            write_chunk_size=2,
+        )
+        first = _make_agent_trajectory(
+            0, episode_length=2, n_colloids=2, base_value=3.0
+        )
+        second = _make_agent_trajectory(
+            0, episode_length=2, n_colloids=2, base_value=7.0
+        )
+
+        storage.write(first)
+        assert storage._write_idx == 0
+
+        storage.write(second)
+        assert storage._write_idx == 2
+
+        file_path = tmp_path / "agent_data_0.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            dataset = h5_file["Agent_0"]["features"]
+            assert dataset.shape == (2, 2, 2, 1)
+            npt.assert_allclose(dataset[0], first.features)
+            npt.assert_allclose(dataset[1], second.features)
+
+    def test_agent_storage_flush_writes_partial_chunk(self, tmp_path: Path):
+        storage = AgentTrajectoryStorage(
+            particle_type=0,
+            out_folder=str(tmp_path),
+            preset="verbose",
+            write_chunk_size=2,
+        )
+        trajectory = _make_agent_trajectory(
+            0, episode_length=2, n_colloids=2, base_value=3.0
+        )
+
+        storage.write(trajectory)
+        storage.flush()
+
+        file_path = tmp_path / "agent_data_0.hdf5"
+        assert storage._write_idx == 1
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            dataset = h5_file["Agent_0"]["features"]
+            assert dataset.shape == (1, 2, 2, 1)
+            npt.assert_allclose(dataset[0], trajectory.features)
+
     def test_agent_storage_supports_vector_features_in_verbose_mode(
         self,
         tmp_path: Path,

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -91,6 +91,28 @@ class TestStorageWriters:
             assert times.shape[0] == 1
             assert np.isclose(times[0, 0, 0], 2.0)
 
+    def test_sim_storage_preserves_existing_groups_when_reusing_file(
+        self, tmp_path: Path
+    ):
+        first_storage = SimulationTrajectoryStorage(
+            out_folder=str(tmp_path),
+            h5_group_tag="0",
+        )
+        first_storage.write(_make_sim_timestep(n_colloids=2, time_value=1.0))
+
+        second_storage = SimulationTrajectoryStorage(
+            out_folder=str(tmp_path),
+            h5_group_tag="1",
+            fail_if_exists=False,
+        )
+        second_storage.write(_make_sim_timestep(n_colloids=2, time_value=2.0))
+
+        file_path = tmp_path / "trajectory.hdf5"
+        with h5py.File(file_path.as_posix(), "r") as h5_file:
+            assert list(h5_file.keys()) == ["0", "1"]
+            assert np.isclose(h5_file["0"]["Times"][0, 0, 0], 1.0)
+            assert np.isclose(h5_file["1"]["Times"][0, 0, 0], 2.0)
+
     def test_agent_storage_fails_if_file_exists_by_default(self, tmp_path: Path):
         first_storage = AgentTrajectoryStorage(
             particle_type=7,

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -81,7 +81,7 @@ class TestStorageWriters:
 
         second_storage = SimulationTrajectoryStorage(
             out_folder=str(tmp_path),
-            fail_if_exists=False,
+            allow_existing_file=True,
         )
         second_storage.write(_make_sim_timestep(n_colloids=2, time_value=2.0))
 
@@ -103,7 +103,7 @@ class TestStorageWriters:
         second_storage = SimulationTrajectoryStorage(
             out_folder=str(tmp_path),
             h5_group_tag="1",
-            fail_if_exists=False,
+            allow_existing_file=True,
         )
         second_storage.write(_make_sim_timestep(n_colloids=2, time_value=2.0))
 
@@ -150,7 +150,7 @@ class TestStorageWriters:
         overwrite_storage = AgentTrajectoryStorage(
             particle_type=8,
             out_folder=str(tmp_path),
-            fail_if_exists=False,
+            allow_existing_file=True,
         )
         overwrite_storage.write(
             _make_agent_trajectory(

--- a/swarmrl/__init__.py
+++ b/swarmrl/__init__.py
@@ -16,10 +16,10 @@ from swarmrl import (
     tasks,
     trainers,
     training_routines,
+    utils,
     value_functions,
 )
 from swarmrl.engine import espresso
-from swarmrl.utils import utils
 
 # Setup a swarmrl logger but disable it.
 # Use logging_utils.setup_swarmrl_logger() to actually enable/configure the logger.

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -35,6 +35,8 @@ class ActorCriticAgent(Agent):
         intrinsic_reward: IntrinsicReward = None,
         save_agent_data_to_file: bool = False,
         out_folder: str = "./agent_data",
+        storage_preset: str = "minimal",
+        stored_fields: list[str] = None,
     ):
         """
         Constructor for the actor-critic protocol.
@@ -59,6 +61,14 @@ class ActorCriticAgent(Agent):
                 Flag to indicate if the agent should record data.
         out_folder : str (default="./agent_data")
             Folder to store the agent data file.
+        storage_preset : str (default="minimal")
+            Preset for storage fields: "minimal" (actions,
+            rewards) or "verbose" (+features, log_probs, killed,
+            particle_type).
+        stored_fields : list (default=None)
+            Explicit whitelist of fields to store
+            (e.g., ["actions", "features"]).
+            Overrides storage_preset if provided.
         """
         # Properties of the agent.
         self.network = network
@@ -79,6 +89,8 @@ class ActorCriticAgent(Agent):
             AgentTrajectoryStorage(
                 particle_type=self.particle_type,
                 out_folder=out_folder,
+                preset=storage_preset,
+                stored_fields=stored_fields,
             )
             if save_agent_data_to_file
             else None

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -120,8 +120,7 @@ class ActorCriticAgent(Agent):
             self.intrinsic_reward.update(self.trajectory)
 
         # Save the agent trajectory data if requested
-        if self.trajectory_storage is not None:
-            self.trajectory_storage.write(self.trajectory)
+        self.persist_trajectory(self.trajectory)
 
         # Reset the trajectory storage.
         self.reset_trajectory()

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -34,7 +34,7 @@ class ActorCriticAgent(Agent):
         train: bool = True,
         intrinsic_reward: IntrinsicReward = None,
         save_agent_data_to_file: bool = False,
-        out_folder: str = "./Agent_Data",
+        out_folder: str = "./agent_data",
     ):
         """
         Constructor for the actor-critic protocol.
@@ -57,7 +57,7 @@ class ActorCriticAgent(Agent):
                 Intrinsic reward to use for the agent.
         save_agent_data_to_file : bool (default=False)
                 Flag to indicate if the agent should record data.
-        out_folder : str (default="./Agent_Data")
+        out_folder : str (default="./agent_data")
             Folder to store the agent data file.
         """
         # Properties of the agent.
@@ -75,7 +75,7 @@ class ActorCriticAgent(Agent):
 
         # Initialize storage only if saving is enabled
         self.save_agent_data_to_file = save_agent_data_to_file
-        self.store_manager = (
+        self.trajectory_storage = (
             AgentTrajectoryStorage(
                 particle_type=self.particle_type,
                 out_folder=out_folder,
@@ -123,7 +123,7 @@ class ActorCriticAgent(Agent):
 
         # Save the agent trajectory data if requested
         if self.save_agent_data_to_file:
-            self.store_manager.write(self.trajectory)
+            self.trajectory_storage.write(self.trajectory)
 
         # Reset the trajectory storage.
         self.reset_trajectory()

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -15,7 +15,7 @@ from swarmrl.networks.network import Network
 from swarmrl.observables.observable import Observable
 from swarmrl.tasks.task import Task
 from swarmrl.utils.colloid_utils import TrajectoryInformation
-from swarmrl.utils.storage_utils import AgentTrajectoryStorage
+from swarmrl.utils.storage_utils import AgentStorageConfig, AgentTrajectoryStorage
 
 
 class ActorCriticAgent(Agent):
@@ -33,10 +33,7 @@ class ActorCriticAgent(Agent):
         loss: Loss = ProximalPolicyLoss(),
         train: bool = True,
         intrinsic_reward: IntrinsicReward = None,
-        save_agent_data_to_file: bool = False,
-        out_folder: str = "./agent_data",
-        storage_preset: str = "minimal",
-        stored_attributes: list[str] = None,
+        storage_config: AgentStorageConfig | None = None,
     ):
         """
         Constructor for the actor-critic protocol.
@@ -57,17 +54,9 @@ class ActorCriticAgent(Agent):
                 Flag to indicate if the agent is training.
         intrinsic_reward : IntrinsicReward (default=None)
                 Intrinsic reward to use for the agent.
-        save_agent_data_to_file : bool (default=False)
-                Flag to indicate if the agent should record data.
-        out_folder : str (default="./agent_data")
-            Folder to store the agent data file.
-        storage_preset : str (default="minimal")
-            Preset for storage fields: "minimal" (actions,
-            rewards) or "verbose" (+features, log_probs, killed).
-        stored_attributes : list (default=None)
-            Explicit whitelist of attributes to store
-            (e.g., ["actions", "features"]).
-            Overrides storage_preset if provided.
+        storage_config : AgentStorageConfig | None (default=None)
+            Optional storage configuration. If None, no trajectory data is
+            persisted to file.
         """
         # Properties of the agent.
         self.network = network
@@ -82,18 +71,16 @@ class ActorCriticAgent(Agent):
         # Trajectory to be updated.
         self.trajectory = TrajectoryInformation(particle_type=self.particle_type)
 
-        # Initialize storage only if saving is enabled
-        self.save_agent_data_to_file = save_agent_data_to_file
-        self.trajectory_storage = (
-            AgentTrajectoryStorage(
+        self.storage_config = storage_config
+        self.trajectory_storage = None
+        if self.storage_config is not None:
+            self.trajectory_storage = AgentTrajectoryStorage(
                 particle_type=self.particle_type,
-                out_folder=out_folder,
-                preset=storage_preset,
-                stored_attributes=stored_attributes,
+                out_folder=self.storage_config.out_folder,
+                preset=self.storage_config.storage_preset,
+                stored_attributes=self.storage_config.stored_attributes,
+                fail_if_exists=self.storage_config.fail_if_exists,
             )
-            if save_agent_data_to_file
-            else None
-        )
 
     def __name__(self) -> str:
         """
@@ -133,7 +120,7 @@ class ActorCriticAgent(Agent):
             self.intrinsic_reward.update(self.trajectory)
 
         # Save the agent trajectory data if requested
-        if self.save_agent_data_to_file:
+        if self.trajectory_storage is not None:
             self.trajectory_storage.write(self.trajectory)
 
         # Reset the trajectory storage.

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -33,7 +33,7 @@ class ActorCriticAgent(Agent):
         loss: Loss = ProximalPolicyLoss(),
         train: bool = True,
         intrinsic_reward: IntrinsicReward = None,
-        save_agent_to_file: bool = False,
+        save_agent_data_to_file: bool = False,
         out_folder: str = "./Agent_Data",
     ):
         """
@@ -55,7 +55,7 @@ class ActorCriticAgent(Agent):
                 Flag to indicate if the agent is training.
         intrinsic_reward : IntrinsicReward (default=None)
                 Intrinsic reward to use for the agent.
-        save_agent_to_file : bool (default=False)
+        save_agent_data_to_file : bool (default=False)
                 Flag to indicate if the agent should record data.
         out_folder : str (default="./Agent_Data")
             Folder to store the agent data file.
@@ -74,13 +74,13 @@ class ActorCriticAgent(Agent):
         self.trajectory = TrajectoryInformation(particle_type=self.particle_type)
 
         # Initialize storage only if saving is enabled
-        self.save_agent_to_file = save_agent_to_file
+        self.save_agent_data_to_file = save_agent_data_to_file
         self.store_manager = (
             AgentTrajectoryStorage(
                 particle_type=self.particle_type,
                 out_folder=out_folder,
             )
-            if save_agent_to_file
+            if save_agent_data_to_file
             else None
         )
 
@@ -122,7 +122,7 @@ class ActorCriticAgent(Agent):
             self.intrinsic_reward.update(self.trajectory)
 
         # Save the agent trajectory data if requested
-        if self.save_agent_to_file:
+        if self.save_agent_data_to_file:
             self.store_manager.write(self.trajectory)
 
         # Reset the trajectory storage.

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -36,7 +36,7 @@ class ActorCriticAgent(Agent):
         save_agent_data_to_file: bool = False,
         out_folder: str = "./agent_data",
         storage_preset: str = "minimal",
-        stored_fields: list[str] = None,
+        stored_attributes: list[str] = None,
     ):
         """
         Constructor for the actor-critic protocol.
@@ -65,8 +65,8 @@ class ActorCriticAgent(Agent):
             Preset for storage fields: "minimal" (actions,
             rewards) or "verbose" (+features, log_probs, killed,
             particle_type).
-        stored_fields : list (default=None)
-            Explicit whitelist of fields to store
+        stored_attributes : list (default=None)
+            Explicit whitelist of attributes to store
             (e.g., ["actions", "features"]).
             Overrides storage_preset if provided.
         """
@@ -90,7 +90,7 @@ class ActorCriticAgent(Agent):
                 particle_type=self.particle_type,
                 out_folder=out_folder,
                 preset=storage_preset,
-                stored_fields=stored_fields,
+                stored_attributes=stored_attributes,
             )
             if save_agent_data_to_file
             else None

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -63,8 +63,7 @@ class ActorCriticAgent(Agent):
             Folder to store the agent data file.
         storage_preset : str (default="minimal")
             Preset for storage fields: "minimal" (actions,
-            rewards) or "verbose" (+features, log_probs, killed,
-            particle_type).
+            rewards) or "verbose" (+features, log_probs, killed).
         stored_attributes : list (default=None)
             Explicit whitelist of attributes to store
             (e.g., ["actions", "features"]).

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -15,6 +15,7 @@ from swarmrl.networks.network import Network
 from swarmrl.observables.observable import Observable
 from swarmrl.tasks.task import Task
 from swarmrl.utils.colloid_utils import TrajectoryInformation
+from swarmrl.utils.storage_utils import AgentTrajectoryStorage
 
 
 class ActorCriticAgent(Agent):
@@ -32,6 +33,8 @@ class ActorCriticAgent(Agent):
         loss: Loss = ProximalPolicyLoss(),
         train: bool = True,
         intrinsic_reward: IntrinsicReward = None,
+        save_agent_to_file: bool = False,
+        out_folder: str = "./Agent_Data",
     ):
         """
         Constructor for the actor-critic protocol.
@@ -52,6 +55,10 @@ class ActorCriticAgent(Agent):
                 Flag to indicate if the agent is training.
         intrinsic_reward : IntrinsicReward (default=None)
                 Intrinsic reward to use for the agent.
+        save_agent_to_file : bool (default=False)
+                Flag to indicate if the agent should record data.
+        out_folder : str (default="./Agent_Data")
+            Folder to store the agent data file.
         """
         # Properties of the agent.
         self.network = network
@@ -65,6 +72,17 @@ class ActorCriticAgent(Agent):
 
         # Trajectory to be updated.
         self.trajectory = TrajectoryInformation(particle_type=self.particle_type)
+
+        # Initialize storage only if saving is enabled
+        self.save_agent_to_file = save_agent_to_file
+        self.store_manager = (
+            AgentTrajectoryStorage(
+                particle_type=self.particle_type,
+                out_folder=out_folder,
+            )
+            if save_agent_to_file
+            else None
+        )
 
     def __name__(self) -> str:
         """
@@ -102,6 +120,10 @@ class ActorCriticAgent(Agent):
         # Update the intrinsic reward if set.
         if self.intrinsic_reward:
             self.intrinsic_reward.update(self.trajectory)
+
+        # Save the agent trajectory data if requested
+        if self.save_agent_to_file:
+            self.store_manager.write(self.trajectory)
 
         # Reset the trajectory storage.
         self.reset_trajectory()

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -79,7 +79,7 @@ class ActorCriticAgent(Agent):
                 out_folder=self.storage_config.out_folder,
                 preset=self.storage_config.storage_preset,
                 stored_attributes=self.storage_config.stored_attributes,
-                fail_if_exists=self.storage_config.fail_if_exists,
+                allow_existing_file=self.storage_config.allow_existing_file,
                 write_chunk_size=self.storage_config.write_chunk_size,
             )
 

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -80,6 +80,7 @@ class ActorCriticAgent(Agent):
                 preset=self.storage_config.storage_preset,
                 stored_attributes=self.storage_config.stored_attributes,
                 fail_if_exists=self.storage_config.fail_if_exists,
+                write_chunk_size=self.storage_config.write_chunk_size,
             )
 
     def __name__(self) -> str:

--- a/swarmrl/agents/agent.py
+++ b/swarmrl/agents/agent.py
@@ -15,6 +15,14 @@ class Agent:
 
     _killed = False
 
+    def persist_trajectory(self, trajectory) -> None:
+        """
+        Persist trajectory data if a storage backend is attached.
+        """
+        storage = getattr(self, "trajectory_storage", None)
+        if storage is not None:
+            storage.write(trajectory)
+
     @property
     def kill_switch(self):
         """

--- a/swarmrl/agents/agent.py
+++ b/swarmrl/agents/agent.py
@@ -52,3 +52,9 @@ class Agent:
                 Flag capable of ending simulation.
         """
         raise NotImplementedError("Implemented in Child class.")
+
+    def finalize_trajectory_storage(self) -> None:
+        """Finalize trajectory storage if a backend is attached."""
+        storage = getattr(self, "trajectory_storage", None)
+        if storage is not None:
+            storage.finalize()

--- a/swarmrl/agents/agent.py
+++ b/swarmrl/agents/agent.py
@@ -23,6 +23,12 @@ class Agent:
         if storage is not None:
             storage.write(trajectory)
 
+    def finalize(self) -> None:
+        """Finalize trajectory storage if a backend is attached."""
+        storage = getattr(self, "trajectory_storage", None)
+        if storage is not None:
+            storage.finalize()
+
     @property
     def kill_switch(self):
         """
@@ -52,9 +58,3 @@ class Agent:
                 Flag capable of ending simulation.
         """
         raise NotImplementedError("Implemented in Child class.")
-
-    def finalize_trajectory_storage(self) -> None:
-        """Finalize trajectory storage if a backend is attached."""
-        storage = getattr(self, "trajectory_storage", None)
-        if storage is not None:
-            storage.finalize()

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -6,7 +6,6 @@ import dataclasses
 import pathlib
 import typing
 
-import h5py
 import numpy as np
 import pint
 from loguru import logger
@@ -14,6 +13,7 @@ from loguru import logger
 import swarmrl.utils.utils as utils
 from swarmrl.components.colloid import Colloid
 from swarmrl.force_functions import ForceFunction
+from swarmrl.utils.storage_utils import SimulationTrajectoryStorage
 
 from .engine import Engine
 
@@ -208,6 +208,8 @@ class EspressoMD(Engine):
             "EXTERNAL_FORCES",
             "THERMOSTAT_PER_PARTICLE",
         ])
+
+        self._trajectory_storage = None
 
     def _init_unit_system(self):
         """
@@ -1076,35 +1078,22 @@ class EspressoMD(Engine):
         }
 
         n_colloids = len(self.colloids)
+        dummy_sample = {
+            "Times": np.array([self.system.time])[:, np.newaxis],
+            "Ids": np.zeros((n_colloids, 1), dtype=int),
+            "Types": np.zeros((n_colloids, 1), dtype=int),
+            "Unwrapped_Positions": np.zeros((n_colloids, 3), dtype=float),
+            "Velocities": np.zeros((n_colloids, 3), dtype=float),
+            "Directors": np.zeros((n_colloids, 3), dtype=float),
+        }
 
-        with h5py.File(self.h5_filename.as_posix(), "a", libver="latest") as h5_outfile:
-            part_group = h5_outfile.require_group(self.h5_group_tag)
-            dataset_kwargs = dict(compression="gzip")
-            traj_len = self.write_chunk_size
+        self._trajectory_storage = SimulationTrajectoryStorage(
+            out_folder=str(self.out_folder),
+            h5_group_tag=self.h5_group_tag,
+        )
+        self._trajectory_storage._init_h5_output(dummy_sample)
 
-            part_group.require_dataset(
-                "Times",
-                shape=(traj_len, 1, 1),
-                maxshape=(None, 1, 1),
-                dtype=float,
-                **dataset_kwargs,
-            )
-            for name in ["Ids", "Types"]:
-                part_group.require_dataset(
-                    name,
-                    shape=(traj_len, n_colloids, 1),
-                    maxshape=(None, n_colloids, 1),
-                    dtype=int,
-                    **dataset_kwargs,
-                )
-            for name in ["Unwrapped_Positions", "Velocities", "Directors"]:
-                part_group.require_dataset(
-                    name,
-                    shape=(traj_len, n_colloids, 3),
-                    maxshape=(None, n_colloids, 3),
-                    dtype=float,
-                    **dataset_kwargs,
-                )
+        self.h5_filename = self._trajectory_storage.h5_filename
         self.write_idx = 0
         self.h5_time_steps_written = 0
 
@@ -1138,23 +1127,12 @@ class EspressoMD(Engine):
         -------
         Adds data to the database and updates the class state.
         """
+
         n_new_timesteps = len(self.traj_holder["Times"])
         if n_new_timesteps == 0:
             return
 
-        with h5py.File(self.h5_filename, "a") as h5_outfile:
-            part_group = h5_outfile[self.h5_group_tag]
-
-            for key in self.traj_holder.keys():
-                dataset = part_group[key]
-                values = np.stack(self.traj_holder[key], axis=0)
-                # save in format (time_step, n_particles, dimension)
-                dataset.resize(self.h5_time_steps_written + n_new_timesteps, axis=0)
-                dataset[
-                    self.h5_time_steps_written : self.h5_time_steps_written
-                    + n_new_timesteps,
-                    ...,
-                ] = values
+        self._trajectory_storage.write_accumulated_batch(self.traj_holder)
 
         logger.debug(f"wrote {n_new_timesteps} time steps to hdf5 file")
         self.h5_time_steps_written += n_new_timesteps

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -148,6 +148,7 @@ class EspressoMD(Engine):
         write_chunk_size=100,
         system=None,
         h5_group_tag=None,
+        fail_if_trajectory_file_exists: bool = True,
     ):
         """
         Constructor for the espressoMD engine.
@@ -171,6 +172,8 @@ class EspressoMD(Engine):
                 Note: We try to clear the passed system of any previous contents,
                 but do not guarantee that everything is reset completely. Use at
                 own risk.
+        fail_if_trajectory_file_exists : bool (default=True)
+            If True, fail when the trajectory output file already exists.
         """
         self.params: MDParams = md_params
         self.out_folder = pathlib.Path(out_folder).resolve()
@@ -187,6 +190,7 @@ class EspressoMD(Engine):
             self.h5_group_tag = "colloids"
         else:
             self.h5_group_tag = h5_group_tag
+        self.fail_if_trajectory_file_exists = fail_if_trajectory_file_exists
 
         if system is None:
             self.system = espressomd.System(box_l=3 * [1.0])
@@ -1090,6 +1094,7 @@ class EspressoMD(Engine):
         self._trajectory_storage = SimulationTrajectoryStorage(
             out_folder=str(self.out_folder),
             h5_group_tag=self.h5_group_tag,
+            fail_if_exists=self.fail_if_trajectory_file_exists,
         )
         self._trajectory_storage._init_h5_output(dummy_sample)
 

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -165,7 +165,9 @@ class EspressoMD(Engine):
                 Path to an output folder to store data in. This file should have a
                 reasonable amount of free space.
         write_chunk_size : int
-                Chunk size to use in the hdf5 writing.
+                Number of sampled trajectory frames buffered in memory before flushing
+                them to the HDF5 file. This does not control the physical sampling
+                interval; use MDParams.write_interval for that.
         system : espressomd.System (optional)
                 Espresso system to use in this engine.
                 If not provided, a new system will be created.

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -1098,7 +1098,7 @@ class EspressoMD(Engine):
             h5_group_tag=self.h5_group_tag,
             allow_existing_file=self.allow_existing_trajectory_file,
         )
-        self._trajectory_storage._init_trajectory_output(dummy_sample)
+        self._trajectory_storage._init_h5_output(dummy_sample)
 
         self.h5_filename = self._trajectory_storage.h5_filename
         self.write_idx = 0

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -1060,7 +1060,7 @@ class EspressoMD(Engine):
             property_dict["radius"],
         )
 
-    def _init_h5_output(self):
+    def _init_trajectory_output(self):
         """
         Initialize the hdf5 output.
 
@@ -1098,7 +1098,7 @@ class EspressoMD(Engine):
             h5_group_tag=self.h5_group_tag,
             fail_if_exists=self.fail_if_trajectory_file_exists,
         )
-        self._trajectory_storage._init_h5_output(dummy_sample)
+        self._trajectory_storage._init_trajectory_output(dummy_sample)
 
         self.h5_filename = self._trajectory_storage.h5_filename
         self.write_idx = 0
@@ -1255,7 +1255,7 @@ class EspressoMD(Engine):
             self.step_idx = 0
             self._setup_interactions()
             self._remove_overlap()
-            self._init_h5_output()
+            self._init_trajectory_output()
             self.integration_initialised = True
 
         old_slice_idx = self.slice_idx

--- a/swarmrl/engine/espresso.py
+++ b/swarmrl/engine/espresso.py
@@ -148,7 +148,7 @@ class EspressoMD(Engine):
         write_chunk_size=100,
         system=None,
         h5_group_tag=None,
-        fail_if_trajectory_file_exists: bool = True,
+        allow_existing_trajectory_file: bool = False,
     ):
         """
         Constructor for the espressoMD engine.
@@ -174,8 +174,8 @@ class EspressoMD(Engine):
                 Note: We try to clear the passed system of any previous contents,
                 but do not guarantee that everything is reset completely. Use at
                 own risk.
-        fail_if_trajectory_file_exists : bool (default=True)
-            If True, fail when the trajectory output file already exists.
+        allow_existing_trajectory_file : bool (default=False)
+            If False, fail when the trajectory output file already exists.
         """
         self.params: MDParams = md_params
         self.out_folder = pathlib.Path(out_folder).resolve()
@@ -192,7 +192,7 @@ class EspressoMD(Engine):
             self.h5_group_tag = "colloids"
         else:
             self.h5_group_tag = h5_group_tag
-        self.fail_if_trajectory_file_exists = fail_if_trajectory_file_exists
+        self.allow_existing_trajectory_file = allow_existing_trajectory_file
 
         if system is None:
             self.system = espressomd.System(box_l=3 * [1.0])
@@ -1096,7 +1096,7 @@ class EspressoMD(Engine):
         self._trajectory_storage = SimulationTrajectoryStorage(
             out_folder=str(self.out_folder),
             h5_group_tag=self.h5_group_tag,
-            fail_if_exists=self.fail_if_trajectory_file_exists,
+            allow_existing_file=self.allow_existing_trajectory_file,
         )
         self._trajectory_storage._init_trajectory_output(dummy_sample)
 

--- a/swarmrl/trainers/continuous_trainer.py
+++ b/swarmrl/trainers/continuous_trainer.py
@@ -119,4 +119,5 @@ class ContinuousTrainer(Trainer):
 
             if not did_finalize:
                 system_runner.finalize()
+        self.finalize_agents()
         return np.array(rewards[:completed_episodes])

--- a/swarmrl/trainers/episodic_trainer.py
+++ b/swarmrl/trainers/episodic_trainer.py
@@ -56,7 +56,7 @@ class EpisodicTrainer(Trainer):
                 system runner supports episodic data saving. The get_engine function
                 should take a system and a str(cycle_index) as arguments. The
                 cycle_index is passed to the EsperessoMD engine as 'h5_group_tag'. See
-                the implementationin the test_semi_episodic_data_writing function in
+                the implementation in the test_semi_episodic_data_writing function in
                 CI/espresso_tests/integration_tests/test_rl_trainers.py
 
         Notes

--- a/swarmrl/trainers/episodic_trainer.py
+++ b/swarmrl/trainers/episodic_trainer.py
@@ -157,4 +157,5 @@ class EpisodicTrainer(Trainer):
                         )
                         break
 
+        self.finalize_agents()
         return np.array(rewards)

--- a/swarmrl/trainers/trainer.py
+++ b/swarmrl/trainers/trainer.py
@@ -117,7 +117,7 @@ class Trainer:
 
     def restore_models(self, directory: str = "Models"):
         """
-        Export the models to the specified directory.
+        Restore the models from the specified directory.
 
         Parameters
         ----------

--- a/swarmrl/trainers/trainer.py
+++ b/swarmrl/trainers/trainer.py
@@ -138,7 +138,7 @@ class Trainer:
     def finalize_agents(self):
         """Finalize agent-side resources after training."""
         for agent in self.agents.values():
-            agent.finalize_trajectory_storage()
+            agent.finalize()
 
     def export_models(self, directory: str = "Models"):
         """

--- a/swarmrl/trainers/trainer.py
+++ b/swarmrl/trainers/trainer.py
@@ -135,6 +135,11 @@ class Trainer:
         interaction_model = ForceFunction(agents=self.agents)
         return interaction_model, np.array(reward), any(switches)
 
+    def finalize_agents(self):
+        """Finalize agent-side resources after training."""
+        for agent in self.agents.values():
+            agent.finalize_trajectory_storage()
+
     def export_models(self, directory: str = "Models"):
         """
         Export the models to the specified directory.

--- a/swarmrl/utils/__init__.py
+++ b/swarmrl/utils/__init__.py
@@ -1,0 +1,20 @@
+"""Public utility exports for the SwarmRL package."""
+
+from swarmrl.utils.colloid_utils import TrajectoryInformation, get_colloid_indices
+from swarmrl.utils.storage_utils import (
+    AgentStorageConfig,
+    AgentTrajectoryStorage,
+    SimulationTrajectoryStorage,
+)
+from swarmrl.utils.utils import create_colloids, setup_sim_folder, write_params
+
+__all__ = [
+    "TrajectoryInformation",
+    "get_colloid_indices",
+    "create_colloids",
+    "setup_sim_folder",
+    "write_params",
+    "AgentStorageConfig",
+    "AgentTrajectoryStorage",
+    "SimulationTrajectoryStorage",
+]

--- a/swarmrl/utils/__init__.py
+++ b/swarmrl/utils/__init__.py
@@ -6,7 +6,14 @@ from swarmrl.utils.storage_utils import (
     AgentTrajectoryStorage,
     SimulationTrajectoryStorage,
 )
-from swarmrl.utils.utils import create_colloids, setup_sim_folder, write_params
+from swarmrl.utils.utils import (
+    calc_ellipsoid_friction_factors_rotation,
+    calc_ellipsoid_friction_factors_translation,
+    convert_array_of_pint_to_pint_of_array,
+    create_colloids,
+    setup_sim_folder,
+    write_params,
+)
 
 __all__ = [
     "TrajectoryInformation",
@@ -14,6 +21,9 @@ __all__ = [
     "create_colloids",
     "setup_sim_folder",
     "write_params",
+    "calc_ellipsoid_friction_factors_translation",
+    "calc_ellipsoid_friction_factors_rotation",
+    "convert_array_of_pint_to_pint_of_array",
     "AgentStorageConfig",
     "AgentTrajectoryStorage",
     "SimulationTrajectoryStorage",

--- a/swarmrl/utils/storage_utils/__init__.py
+++ b/swarmrl/utils/storage_utils/__init__.py
@@ -2,6 +2,7 @@
 
 from swarmrl.utils.storage_utils.core_storage import HDF5TrajectoryStorage
 from swarmrl.utils.storage_utils.trajectory_storage import (
+    AgentStorageConfig,
     AgentTrajectoryStorage,
     DictTrajectoryStorage,
     SimulationTrajectoryStorage,
@@ -10,6 +11,7 @@ from swarmrl.utils.storage_utils.trajectory_storage import (
 __all__ = [
     "HDF5TrajectoryStorage",
     "DictTrajectoryStorage",
+    "AgentStorageConfig",
     "AgentTrajectoryStorage",
     "SimulationTrajectoryStorage",
 ]

--- a/swarmrl/utils/storage_utils/__init__.py
+++ b/swarmrl/utils/storage_utils/__init__.py
@@ -1,0 +1,15 @@
+"""Storage utilities for trajectory persistence."""
+
+from swarmrl.utils.storage_utils.core_storage import HDF5TrajectoryStorage
+from swarmrl.utils.storage_utils.trajectory_storage import (
+    AgentTrajectoryStorage,
+    DictTrajectoryStorage,
+    SimulationTrajectoryStorage,
+)
+
+__all__ = [
+    "HDF5TrajectoryStorage",
+    "DictTrajectoryStorage",
+    "AgentTrajectoryStorage",
+    "SimulationTrajectoryStorage",
+]

--- a/swarmrl/utils/storage_utils/__init__.py
+++ b/swarmrl/utils/storage_utils/__init__.py
@@ -4,13 +4,11 @@ from swarmrl.utils.storage_utils.core_storage import HDF5TrajectoryStorage
 from swarmrl.utils.storage_utils.trajectory_storage import (
     AgentStorageConfig,
     AgentTrajectoryStorage,
-    DictTrajectoryStorage,
     SimulationTrajectoryStorage,
 )
 
 __all__ = [
     "HDF5TrajectoryStorage",
-    "DictTrajectoryStorage",
     "AgentStorageConfig",
     "AgentTrajectoryStorage",
     "SimulationTrajectoryStorage",

--- a/swarmrl/utils/storage_utils/core_storage.py
+++ b/swarmrl/utils/storage_utils/core_storage.py
@@ -18,7 +18,7 @@ class HDF5TrajectoryStorage(ABC):
 
     def __init__(
         self,
-        out_folder: str = "./Data",
+        out_folder: str = "./data",
         filename: str = "trajectory.hdf5",
     ):
         self.out_folder = pathlib.Path(out_folder)

--- a/swarmrl/utils/storage_utils/core_storage.py
+++ b/swarmrl/utils/storage_utils/core_storage.py
@@ -1,0 +1,119 @@
+"""Core abstractions for HDF5 trajectory storage."""
+
+import pathlib
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+import h5py
+import numpy as np
+
+
+class HDF5TrajectoryStorage(ABC):
+    """
+    Abstract base class for HDF5-based trajectory storage, handling
+    - file initialization
+    - dataset creation,
+    - batch writing with proper indexing.
+    """
+
+    def __init__(
+        self,
+        out_folder: str = "./Data",
+        filename: str = "trajectory.hdf5",
+    ):
+        self.out_folder = pathlib.Path(out_folder)
+        self.h5_filename = self.out_folder / filename
+
+        # Internal state
+        self._is_initialized = False
+        self._write_idx = 0
+        self._data_holder = None
+        self._h5_group_tag = None
+
+    @abstractmethod
+    def _get_dataset_specs(self, data_sample: Any) -> Dict[str, Dict[str, Any]]:
+        """Return dataset specifications inferred from one sample."""
+        pass
+
+    @abstractmethod
+    def _initialize_data_holder(self) -> Dict[str, List]:
+        """Create an empty in-memory holder for pending writes."""
+        pass
+
+    @abstractmethod
+    def _accumulate_data(self, data: Any) -> None:
+        """Accumulate one sample into the data holder."""
+        pass
+
+    def _init_h5_output(self, data_sample: Any) -> None:
+        self.out_folder.mkdir(parents=True, exist_ok=True)
+        self._data_holder = self._initialize_data_holder()
+
+        dataset_specs = self._get_dataset_specs(data_sample)
+
+        with h5py.File(self.h5_filename.as_posix(), "a", libver="latest") as h5_outfile:
+            group = h5_outfile.require_group(self._h5_group_tag)
+            dataset_kwargs = dict(compression="gzip")
+
+            for name, spec in dataset_specs.items():
+                group.require_dataset(
+                    name,
+                    shape=spec["shape"],
+                    maxshape=spec["maxshape"],
+                    dtype=spec["dtype"],
+                    **dataset_kwargs,
+                )
+
+        self._is_initialized = True
+        self._write_idx = 0
+
+    def _write_to_h5(self) -> None:
+        if not self._data_holder or all(
+            len(v) == 0 for v in self._data_holder.values()
+        ):
+            return
+
+        with h5py.File(self.h5_filename.as_posix(), "a", libver="latest") as h5_outfile:
+            group = h5_outfile[self._h5_group_tag]
+
+            for key in self._data_holder.keys():
+                dataset = group[key]
+                values = np.stack(self._data_holder[key], axis=0)
+                n_new = values.shape[0]
+
+                dataset.resize(self._write_idx + n_new, axis=0)
+                dataset[self._write_idx : self._write_idx + n_new] = values
+
+            self._write_idx += n_new
+
+        self._data_holder = self._initialize_data_holder()
+
+    def write(self, data: Any) -> None:
+        if not self._is_initialized:
+            self._init_h5_output(data)
+
+        self._accumulate_data(data)
+        self._write_to_h5()
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._is_initialized
+
+    def write_accumulated_batch(self, accumulated_data: Dict[str, List]) -> None:
+        if not accumulated_data or all(len(v) == 0 for v in accumulated_data.values()):
+            return
+
+        with h5py.File(self.h5_filename.as_posix(), "a", libver="latest") as h5_outfile:
+            group = h5_outfile[self._h5_group_tag]
+
+            n_new = None
+            for key in accumulated_data.keys():
+                dataset = group[key]
+                values = np.stack(accumulated_data[key], axis=0)
+                n_new = values.shape[0]
+
+                dataset.resize(self._write_idx + n_new, axis=0)
+                dataset[self._write_idx : self._write_idx + n_new] = values
+
+            if n_new is not None:
+                self._write_idx += n_new

--- a/swarmrl/utils/storage_utils/core_storage.py
+++ b/swarmrl/utils/storage_utils/core_storage.py
@@ -20,9 +20,11 @@ class HDF5TrajectoryStorage(ABC):
         self,
         out_folder: str = "./data",
         filename: str = "trajectory.hdf5",
+        fail_if_exists: bool = False,
     ):
         self.out_folder = pathlib.Path(out_folder)
         self.h5_filename = self.out_folder / filename
+        self.fail_if_exists = fail_if_exists
 
         # Internal state
         self._is_initialized = False
@@ -46,6 +48,12 @@ class HDF5TrajectoryStorage(ABC):
         pass
 
     def _init_h5_output(self, data_sample: Any) -> None:
+        if self.fail_if_exists and self.h5_filename.exists():
+            raise FileExistsError(
+                f"Refusing to write to existing file: {self.h5_filename}. "
+                "Set fail_if_exists=False if you know what you're doing."
+            )
+
         self.out_folder.mkdir(parents=True, exist_ok=True)
         self._data_holder = self._initialize_data_holder()
 

--- a/swarmrl/utils/storage_utils/core_storage.py
+++ b/swarmrl/utils/storage_utils/core_storage.py
@@ -127,7 +127,7 @@ class HDF5TrajectoryStorage(ABC):
         ):
             self._write_to_h5()
 
-    def flush(self) -> None:
+    def finalize(self) -> None:
         """Write any buffered samples to HDF5."""
         self._write_to_h5()
 

--- a/swarmrl/utils/storage_utils/core_storage.py
+++ b/swarmrl/utils/storage_utils/core_storage.py
@@ -20,7 +20,7 @@ class HDF5TrajectoryStorage(ABC):
         self,
         out_folder: str = "./data",
         filename: str = "trajectory.hdf5",
-        fail_if_exists: bool = False,
+        allow_existing_file: bool = False,
         write_chunk_size: int = 1,
     ):
         if write_chunk_size < 1:
@@ -28,7 +28,7 @@ class HDF5TrajectoryStorage(ABC):
 
         self.out_folder = pathlib.Path(out_folder)
         self.h5_filename = self.out_folder / filename
-        self.fail_if_exists = fail_if_exists
+        self.allow_existing_file = allow_existing_file
         self.write_chunk_size = write_chunk_size
 
         # Internal state
@@ -61,10 +61,10 @@ class HDF5TrajectoryStorage(ABC):
             self._data_holder[key].append(sample[key])
 
     def _init_h5_output(self, data_sample: Any) -> None:
-        if self.fail_if_exists and self.h5_filename.exists():
+        if not self.allow_existing_file and self.h5_filename.exists():
             raise FileExistsError(
                 f"Refusing to write to existing file: {self.h5_filename}. "
-                "Set fail_if_exists=False if you know what you're doing."
+                "Set allow_existing_file=True if reusing it is intentional."
             )
 
         dataset_specs = self._get_dataset_specs(data_sample)

--- a/swarmrl/utils/storage_utils/core_storage.py
+++ b/swarmrl/utils/storage_utils/core_storage.py
@@ -21,16 +21,22 @@ class HDF5TrajectoryStorage(ABC):
         out_folder: str = "./data",
         filename: str = "trajectory.hdf5",
         fail_if_exists: bool = False,
+        write_chunk_size: int = 1,
     ):
+        if write_chunk_size < 1:
+            raise ValueError("write_chunk_size must be at least 1")
+
         self.out_folder = pathlib.Path(out_folder)
         self.h5_filename = self.out_folder / filename
         self.fail_if_exists = fail_if_exists
+        self.write_chunk_size = write_chunk_size
 
         # Internal state
         self._is_initialized = False
         self._write_idx = 0
         self._data_holder = None
         self._h5_group_tag = None
+        self._dataset_keys = []
 
     @abstractmethod
     def _get_dataset_specs(self, data_sample: Any) -> Dict[str, Dict[str, Any]]:
@@ -38,14 +44,21 @@ class HDF5TrajectoryStorage(ABC):
         pass
 
     @abstractmethod
-    def _initialize_data_holder(self) -> Dict[str, List]:
-        """Create an empty in-memory holder for pending writes."""
+    def _extract_sample(self, data_sample: Any) -> Dict[str, Any]:
+        """Return one sample mapped by HDF5 dataset name."""
         pass
 
-    @abstractmethod
-    def _accumulate_data(self, data: Any) -> None:
-        """Accumulate one sample into the data holder."""
-        pass
+    def _initialize_data_holder(self) -> Dict[str, List]:
+        """Create an empty in-memory holder for pending writes."""
+        return {key: list() for key in self._dataset_keys}
+
+    def _accumulate_sample(self, sample: Dict[str, Any]) -> None:
+        if self._data_holder is None:
+            self._dataset_keys = list(sample.keys())
+            self._data_holder = self._initialize_data_holder()
+
+        for key in self._dataset_keys:
+            self._data_holder[key].append(sample[key])
 
     def _init_h5_output(self, data_sample: Any) -> None:
         if self.fail_if_exists and self.h5_filename.exists():
@@ -54,19 +67,23 @@ class HDF5TrajectoryStorage(ABC):
                 "Set fail_if_exists=False if you know what you're doing."
             )
 
+        dataset_specs = self._get_dataset_specs(data_sample)
+        self._dataset_keys = list(dataset_specs.keys())
         self.out_folder.mkdir(parents=True, exist_ok=True)
         self._data_holder = self._initialize_data_holder()
-
-        dataset_specs = self._get_dataset_specs(data_sample)
 
         with h5py.File(self.h5_filename.as_posix(), "a", libver="latest") as h5_outfile:
             group = h5_outfile.require_group(self._h5_group_tag)
             dataset_kwargs = dict(compression="gzip")
 
             for name, spec in dataset_specs.items():
-                group.require_dataset(
+                if name in group:
+                    continue
+
+                initial_shape = (0, *spec["shape"][1:])
+                group.create_dataset(
                     name,
-                    shape=spec["shape"],
+                    shape=initial_shape,
                     maxshape=spec["maxshape"],
                     dtype=spec["dtype"],
                     **dataset_kwargs,
@@ -100,7 +117,18 @@ class HDF5TrajectoryStorage(ABC):
         if not self._is_initialized:
             self._init_h5_output(data)
 
-        self._accumulate_data(data)
+        sample = self._extract_sample(data)
+        self._accumulate_sample(sample)
+
+        first_key = self._dataset_keys[0] if self._dataset_keys else None
+        if (
+            first_key is not None
+            and len(self._data_holder[first_key]) >= self.write_chunk_size
+        ):
+            self._write_to_h5()
+
+    def flush(self) -> None:
+        """Write any buffered samples to HDF5."""
         self._write_to_h5()
 
     @property

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -24,8 +24,13 @@ class DictTrajectoryStorage(HDF5TrajectoryStorage):
         h5_group_tag: str,
         dataset_specs_builder: Callable[[Any], Dict[str, Dict[str, Any]]],
         sample_extractor: Callable[[Any], Dict[str, Any]],
+        fail_if_exists: bool = False,
     ):
-        super().__init__(out_folder=out_folder, filename=filename)
+        super().__init__(
+            out_folder=out_folder,
+            filename=filename,
+            fail_if_exists=fail_if_exists,
+        )
         self._h5_group_tag = h5_group_tag
         self._dataset_specs_builder = dataset_specs_builder
         self._sample_extractor = sample_extractor
@@ -99,8 +104,6 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         fail_if_exists : bool (default=True)
             If True, raise FileExistsError when the target file already exists.
         """
-        self.fail_if_exists = fail_if_exists
-
         if stored_attributes is None:
             if preset not in self.PRESETS:
                 raise ValueError(f"preset must be one of {list(self.PRESETS.keys())}")
@@ -140,6 +143,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
             h5_group_tag=f"Agent_{particle_type}",
             dataset_specs_builder=self._build_agent_specs,
             sample_extractor=self._extract_agent_sample,
+            fail_if_exists=fail_if_exists,
         )
         self.particle_type = particle_type
 
@@ -207,14 +211,6 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
 
         return sample
 
-    def _init_h5_output(self, data_sample: Any) -> None:
-        if self.fail_if_exists and self.h5_filename.exists():
-            raise FileExistsError(
-                f"Refusing to write to existing file: {self.h5_filename}. "
-                "Set fail_if_exists=False if you know what you're doing."
-            )
-        super()._init_h5_output(data_sample)
-
 
 @dataclass
 class AgentStorageConfig:
@@ -233,6 +229,7 @@ class SimulationTrajectoryStorage(DictTrajectoryStorage):
         self,
         out_folder: str = "./trajectories",
         h5_group_tag: str = "colloids",
+        fail_if_exists: bool = True,
     ):
         super().__init__(
             out_folder=out_folder,
@@ -240,6 +237,7 @@ class SimulationTrajectoryStorage(DictTrajectoryStorage):
             h5_group_tag=h5_group_tag,
             dataset_specs_builder=self._build_simulation_specs,
             sample_extractor=self._extract_simulation_sample,
+            fail_if_exists=fail_if_exists,
         )
 
     @staticmethod

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -1,0 +1,169 @@
+"""Trajectory storages for agent and simulation data."""
+
+from typing import Any, Callable, Dict, List
+
+import numpy as np
+
+from swarmrl.utils.storage_utils.core_storage import HDF5TrajectoryStorage
+
+
+class DictTrajectoryStorage(HDF5TrajectoryStorage):
+    """
+    Generic dict-based trajectory storage.
+
+    Concrete users provide:
+    - a dataset spec builder from one sample
+    - a sample extractor that returns a dict keyed like the dataset names
+    """
+
+    def __init__(
+        self,
+        out_folder: str,
+        filename: str,
+        h5_group_tag: str,
+        dataset_specs_builder: Callable[[Any], Dict[str, Dict[str, Any]]],
+        sample_extractor: Callable[[Any], Dict[str, Any]],
+    ):
+        super().__init__(out_folder=out_folder, filename=filename)
+        self._h5_group_tag = h5_group_tag
+        self._dataset_specs_builder = dataset_specs_builder
+        self._sample_extractor = sample_extractor
+        self._dataset_keys: List[str] = []
+
+    def _get_dataset_specs(self, data_sample: Any) -> Dict[str, Dict[str, Any]]:
+        specs = self._dataset_specs_builder(data_sample)
+        self._dataset_keys = list(specs.keys())
+        return specs
+
+    def _initialize_data_holder(self) -> Dict[str, List]:
+        return {key: list() for key in self._dataset_keys}
+
+    def _accumulate_data(self, data: Any) -> None:
+        sample = self._sample_extractor(data)
+
+        if not self._data_holder:
+            self._dataset_keys = list(sample.keys())
+            self._data_holder = self._initialize_data_holder()
+
+        for key in self._dataset_keys:
+            self._data_holder[key].append(sample[key])
+
+
+class AgentTrajectoryStorage(DictTrajectoryStorage):
+    """HDF5 storage for agent trajectory data."""
+
+    def __init__(
+        self,
+        particle_type: int,
+        out_folder: str = "./Agent_Data",
+    ):
+        super().__init__(
+            out_folder=out_folder,
+            filename=f"agent_data_{particle_type}.hdf5",
+            h5_group_tag=f"Agent_{particle_type}",
+            dataset_specs_builder=self._build_agent_specs,
+            sample_extractor=self._extract_agent_sample,
+        )
+        self.particle_type = particle_type
+
+    @staticmethod
+    def _build_agent_specs(trajectory) -> Dict[str, Dict[str, Any]]:
+        n_colloids = np.array(trajectory.features).shape[1]
+        episode_length = np.array(trajectory.features).shape[0]
+
+        return {
+            "features": {
+                "shape": (1, episode_length, n_colloids, 1),
+                "maxshape": (None, episode_length, n_colloids, 1),
+                "dtype": np.float32,
+            },
+            "actions": {
+                "shape": (1, episode_length, n_colloids),
+                "maxshape": (None, episode_length, n_colloids),
+                "dtype": int,
+            },
+            "log_probs": {
+                "shape": (1, episode_length, n_colloids),
+                "maxshape": (None, episode_length, n_colloids),
+                "dtype": float,
+            },
+            "rewards": {
+                "shape": (1, episode_length, n_colloids),
+                "maxshape": (None, episode_length, n_colloids),
+                "dtype": float,
+            },
+        }
+
+    @staticmethod
+    def _extract_agent_sample(trajectory) -> Dict[str, Any]:
+        return {
+            "features": trajectory.features,
+            "actions": trajectory.actions,
+            "log_probs": trajectory.log_probs,
+            "rewards": trajectory.rewards,
+        }
+
+
+class SimulationTrajectoryStorage(DictTrajectoryStorage):
+    """HDF5 storage for simulation trajectory data."""
+
+    def __init__(
+        self,
+        out_folder: str = "./trajectories",
+        h5_group_tag: str = "colloids",
+    ):
+        super().__init__(
+            out_folder=out_folder,
+            filename="trajectory.hdf5",
+            h5_group_tag=h5_group_tag,
+            dataset_specs_builder=self._build_simulation_specs,
+            sample_extractor=self._extract_simulation_sample,
+        )
+
+    @staticmethod
+    def _build_simulation_specs(timestep_data: Dict) -> Dict[str, Dict[str, Any]]:
+        n_particles = len(timestep_data.get("Ids", []))
+
+        return {
+            "Times": {
+                "shape": (1, 1, 1),
+                "maxshape": (None, 1, 1),
+                "dtype": float,
+            },
+            "Ids": {
+                "shape": (1, n_particles, 1),
+                "maxshape": (None, n_particles, 1),
+                "dtype": int,
+            },
+            "Types": {
+                "shape": (1, n_particles, 1),
+                "maxshape": (None, n_particles, 1),
+                "dtype": int,
+            },
+            "Unwrapped_Positions": {
+                "shape": (1, n_particles, 3),
+                "maxshape": (None, n_particles, 3),
+                "dtype": float,
+            },
+            "Velocities": {
+                "shape": (1, n_particles, 3),
+                "maxshape": (None, n_particles, 3),
+                "dtype": float,
+            },
+            "Directors": {
+                "shape": (1, n_particles, 3),
+                "maxshape": (None, n_particles, 3),
+                "dtype": float,
+            },
+        }
+
+    @staticmethod
+    def _extract_simulation_sample(timestep_data: Dict) -> Dict[str, Any]:
+        return {
+            "Times": timestep_data["Times"],
+            "Ids": timestep_data["Ids"],
+            "Types": timestep_data["Types"],
+            "Unwrapped_Positions": timestep_data["Unwrapped_Positions"],
+            "Velocities": timestep_data["Velocities"],
+            "Directors": timestep_data["Directors"],
+        }

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -1,5 +1,6 @@
 """Trajectory storages for agent and simulation data."""
 
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List
 
 import numpy as np
@@ -77,6 +78,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         out_folder: str = "./Agent_Data",
         preset: str = "minimal",
         stored_attributes: list = None,
+        fail_if_exists: bool = True,
     ):
         """
         Initialize agent trajectory storage.
@@ -94,7 +96,11 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
             Explicit whitelist of attributes to store
             (e.g., ["actions", "features"]).
             Overrides preset if provided.
+        fail_if_exists : bool (default=True)
+            If True, raise FileExistsError when the target file already exists.
         """
+        self.fail_if_exists = fail_if_exists
+
         if stored_attributes is None:
             if preset not in self.PRESETS:
                 raise ValueError(f"preset must be one of {list(self.PRESETS.keys())}")
@@ -200,6 +206,24 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
                     sample["features"] = trajectory.features
 
         return sample
+
+    def _init_h5_output(self, data_sample: Any) -> None:
+        if self.fail_if_exists and self.h5_filename.exists():
+            raise FileExistsError(
+                f"Refusing to write to existing file: {self.h5_filename}. "
+                "Set fail_if_exists=False if you know what you're doing."
+            )
+        super()._init_h5_output(data_sample)
+
+
+@dataclass
+class AgentStorageConfig:
+    """Configuration for optional agent trajectory storage."""
+
+    out_folder: str = "./agent_data"
+    storage_preset: str = "minimal"
+    stored_attributes: list[str] | None = None
+    fail_if_exists: bool = True
 
 
 class SimulationTrajectoryStorage(DictTrajectoryStorage):

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -58,7 +58,6 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         "rewards",
         "features",
         "killed",
-        "particle_type",
     }
 
     PRESETS = {
@@ -69,7 +68,6 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
             "rewards",
             "features",
             "killed",
-            "particle_type",
         ],
     }
 
@@ -181,14 +179,6 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
                 "dtype": killed.dtype,
             }
 
-        if "particle_type" in self.stored_attributes:
-            particle_type = np.asarray([trajectory.particle_type], dtype=np.int64)
-            specs["particle_type"] = {
-                "shape": (1, 1),
-                "maxshape": (None, 1),
-                "dtype": particle_type.dtype,
-            }
-
         return specs
 
     def _extract_agent_sample(self, trajectory) -> Dict[str, Any]:
@@ -202,11 +192,6 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
             sample["rewards"] = trajectory.rewards
         if "killed" in self.stored_attributes:
             sample["killed"] = np.asarray([trajectory.killed], dtype=np.bool_)
-        if "particle_type" in self.stored_attributes:
-            sample["particle_type"] = np.asarray(
-                [trajectory.particle_type],
-                dtype=np.int64,
-            )
 
         if "features" in self.stored_attributes:
             if getattr(trajectory, "features", None) is not None:

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -78,7 +78,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         particle_type: int,
         out_folder: str = "./Agent_Data",
         preset: str = "minimal",
-        stored_fields: list = None,
+        stored_attributes: list = None,
     ):
         """
         Initialize agent trajectory storage.
@@ -91,38 +91,44 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
             Output folder path.
         preset : str (default="minimal")
             Preset for storage: "minimal" or "verbose".
-            Ignored if stored_fields is provided.
-        stored_fields : list (default=None)
-            Explicit whitelist of fields to store
+            Ignored if stored_attributes is provided.
+        stored_attributes : list (default=None)
+            Explicit whitelist of attributes to store
             (e.g., ["actions", "features"]).
             Overrides preset if provided.
         """
-        if stored_fields is None:
+        if stored_attributes is None:
             if preset not in self.PRESETS:
                 raise ValueError(f"preset must be one of {list(self.PRESETS.keys())}")
-            self.stored_fields = list(self.PRESETS[preset])
+            self.stored_attributes = list(self.PRESETS[preset])
         else:
-            if not isinstance(stored_fields, (list, tuple, set)):
+            if not isinstance(stored_attributes, (list, tuple, set)):
                 raise TypeError(
-                    "stored_fields must be a list, tuple, or set of field names"
+                    "stored_attributes must be a list, tuple, or set of "
+                    "attribute names"
                 )
 
             # Deduplicate while preserving order.
-            normalized_fields = list(dict.fromkeys(stored_fields))
+            normalized_attributes = list(dict.fromkeys(stored_attributes))
 
-            if len(normalized_fields) == 0:
-                raise ValueError("stored_fields must contain at least one field")
-
-            unknown_fields = [
-                field for field in normalized_fields if field not in self.ALLOWED_FIELDS
-            ]
-            if unknown_fields:
+            if len(normalized_attributes) == 0:
                 raise ValueError(
-                    "Unknown stored_fields: "
-                    f"{unknown_fields}. Allowed: {sorted(self.ALLOWED_FIELDS)}"
+                    "stored_attributes must contain at least one attribute"
                 )
 
-            self.stored_fields = normalized_fields
+            unknown_attributes = [
+                attribute
+                for attribute in normalized_attributes
+                if attribute not in self.ALLOWED_FIELDS
+            ]
+            if unknown_attributes:
+                raise ValueError(
+                    "Unknown stored_attributes: "
+                    f"{unknown_attributes}. "
+                    f"Allowed: {sorted(self.ALLOWED_FIELDS)}"
+                )
+
+            self.stored_attributes = normalized_attributes
 
         super().__init__(
             out_folder=out_folder,
@@ -136,21 +142,21 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
     def _build_agent_specs(self, trajectory) -> Dict[str, Dict[str, Any]]:
         specs = {}
 
-        if "actions" in self.stored_fields:
+        if "actions" in self.stored_attributes:
             actions = np.asarray(trajectory.actions)
             specs["actions"] = {
                 "shape": (1, *actions.shape),
                 "maxshape": (None, *actions.shape),
                 "dtype": actions.dtype,
             }
-        if "log_probs" in self.stored_fields:
+        if "log_probs" in self.stored_attributes:
             log_probs = np.asarray(trajectory.log_probs)
             specs["log_probs"] = {
                 "shape": (1, *log_probs.shape),
                 "maxshape": (None, *log_probs.shape),
                 "dtype": log_probs.dtype,
             }
-        if "rewards" in self.stored_fields:
+        if "rewards" in self.stored_attributes:
             rewards = np.asarray(trajectory.rewards)
             specs["rewards"] = {
                 "shape": (1, *rewards.shape),
@@ -158,7 +164,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
                 "dtype": rewards.dtype,
             }
 
-        if "features" in self.stored_fields:
+        if "features" in self.stored_attributes:
             if getattr(trajectory, "features", None) is not None:
                 features = np.asarray(trajectory.features)
                 if features.size > 0:
@@ -167,7 +173,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
                         "maxshape": (None, *features.shape),
                         "dtype": features.dtype,
                     }
-        if "killed" in self.stored_fields:
+        if "killed" in self.stored_attributes:
             killed = np.asarray([trajectory.killed], dtype=np.bool_)
             specs["killed"] = {
                 "shape": (1, 1),
@@ -175,7 +181,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
                 "dtype": killed.dtype,
             }
 
-        if "particle_type" in self.stored_fields:
+        if "particle_type" in self.stored_attributes:
             particle_type = np.asarray([trajectory.particle_type], dtype=np.int64)
             specs["particle_type"] = {
                 "shape": (1, 1),
@@ -188,21 +194,21 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
     def _extract_agent_sample(self, trajectory) -> Dict[str, Any]:
         sample = {}
 
-        if "actions" in self.stored_fields:
+        if "actions" in self.stored_attributes:
             sample["actions"] = trajectory.actions
-        if "log_probs" in self.stored_fields:
+        if "log_probs" in self.stored_attributes:
             sample["log_probs"] = trajectory.log_probs
-        if "rewards" in self.stored_fields:
+        if "rewards" in self.stored_attributes:
             sample["rewards"] = trajectory.rewards
-        if "killed" in self.stored_fields:
+        if "killed" in self.stored_attributes:
             sample["killed"] = np.asarray([trajectory.killed], dtype=np.bool_)
-        if "particle_type" in self.stored_fields:
+        if "particle_type" in self.stored_attributes:
             sample["particle_type"] = np.asarray(
                 [trajectory.particle_type],
                 dtype=np.int64,
             )
 
-        if "features" in self.stored_fields:
+        if "features" in self.stored_attributes:
             if getattr(trajectory, "features", None) is not None:
                 features = np.asarray(trajectory.features)
                 if features.size > 0:

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -11,7 +11,7 @@ class DictTrajectoryStorage(HDF5TrajectoryStorage):
     """
     Generic dict-based trajectory storage.
 
-    Concrete users provide:
+    Provides:
     - a dataset spec builder from one sample
     - a sample extractor that returns a dict keyed like the dataset names
     """
@@ -50,13 +50,80 @@ class DictTrajectoryStorage(HDF5TrajectoryStorage):
 
 
 class AgentTrajectoryStorage(DictTrajectoryStorage):
-    """HDF5 storage for agent trajectory data."""
+    """HDF5 storage for agent trajectory data with configurable fields."""
+
+    ALLOWED_FIELDS = {
+        "actions",
+        "log_probs",
+        "rewards",
+        "features",
+        "killed",
+        "particle_type",
+    }
+
+    PRESETS = {
+        "minimal": ["actions", "rewards"],
+        "verbose": [
+            "actions",
+            "log_probs",
+            "rewards",
+            "features",
+            "killed",
+            "particle_type",
+        ],
+    }
 
     def __init__(
         self,
         particle_type: int,
         out_folder: str = "./Agent_Data",
+        preset: str = "minimal",
+        stored_fields: list = None,
     ):
+        """
+        Initialize agent trajectory storage.
+
+        Parameters
+        ----------
+        particle_type : int
+            Particle type ID.
+        out_folder : str (default="./Agent_Data")
+            Output folder path.
+        preset : str (default="minimal")
+            Preset for storage: "minimal" or "verbose".
+            Ignored if stored_fields is provided.
+        stored_fields : list (default=None)
+            Explicit whitelist of fields to store
+            (e.g., ["actions", "features"]).
+            Overrides preset if provided.
+        """
+        if stored_fields is None:
+            if preset not in self.PRESETS:
+                raise ValueError(f"preset must be one of {list(self.PRESETS.keys())}")
+            self.stored_fields = list(self.PRESETS[preset])
+        else:
+            if not isinstance(stored_fields, (list, tuple, set)):
+                raise TypeError(
+                    "stored_fields must be a list, tuple, or set of field names"
+                )
+
+            # Deduplicate while preserving order.
+            normalized_fields = list(dict.fromkeys(stored_fields))
+
+            if len(normalized_fields) == 0:
+                raise ValueError("stored_fields must contain at least one field")
+
+            unknown_fields = [
+                field for field in normalized_fields if field not in self.ALLOWED_FIELDS
+            ]
+            if unknown_fields:
+                raise ValueError(
+                    "Unknown stored_fields: "
+                    f"{unknown_fields}. Allowed: {sorted(self.ALLOWED_FIELDS)}"
+                )
+
+            self.stored_fields = normalized_fields
+
         super().__init__(
             out_folder=out_folder,
             filename=f"agent_data_{particle_type}.hdf5",
@@ -66,42 +133,82 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         )
         self.particle_type = particle_type
 
-    @staticmethod
-    def _build_agent_specs(trajectory) -> Dict[str, Dict[str, Any]]:
-        n_colloids = np.array(trajectory.features).shape[1]
-        episode_length = np.array(trajectory.features).shape[0]
+    def _build_agent_specs(self, trajectory) -> Dict[str, Dict[str, Any]]:
+        specs = {}
 
-        return {
-            "features": {
-                "shape": (1, episode_length, n_colloids, 1),
-                "maxshape": (None, episode_length, n_colloids, 1),
-                "dtype": np.float32,
-            },
-            "actions": {
-                "shape": (1, episode_length, n_colloids),
-                "maxshape": (None, episode_length, n_colloids),
-                "dtype": int,
-            },
-            "log_probs": {
-                "shape": (1, episode_length, n_colloids),
-                "maxshape": (None, episode_length, n_colloids),
-                "dtype": float,
-            },
-            "rewards": {
-                "shape": (1, episode_length, n_colloids),
-                "maxshape": (None, episode_length, n_colloids),
-                "dtype": float,
-            },
-        }
+        if "actions" in self.stored_fields:
+            actions = np.asarray(trajectory.actions)
+            specs["actions"] = {
+                "shape": (1, *actions.shape),
+                "maxshape": (None, *actions.shape),
+                "dtype": actions.dtype,
+            }
+        if "log_probs" in self.stored_fields:
+            log_probs = np.asarray(trajectory.log_probs)
+            specs["log_probs"] = {
+                "shape": (1, *log_probs.shape),
+                "maxshape": (None, *log_probs.shape),
+                "dtype": log_probs.dtype,
+            }
+        if "rewards" in self.stored_fields:
+            rewards = np.asarray(trajectory.rewards)
+            specs["rewards"] = {
+                "shape": (1, *rewards.shape),
+                "maxshape": (None, *rewards.shape),
+                "dtype": rewards.dtype,
+            }
 
-    @staticmethod
-    def _extract_agent_sample(trajectory) -> Dict[str, Any]:
-        return {
-            "features": trajectory.features,
-            "actions": trajectory.actions,
-            "log_probs": trajectory.log_probs,
-            "rewards": trajectory.rewards,
-        }
+        if "features" in self.stored_fields:
+            if getattr(trajectory, "features", None) is not None:
+                features = np.asarray(trajectory.features)
+                if features.size > 0:
+                    specs["features"] = {
+                        "shape": (1, *features.shape),
+                        "maxshape": (None, *features.shape),
+                        "dtype": features.dtype,
+                    }
+        if "killed" in self.stored_fields:
+            killed = np.asarray([trajectory.killed], dtype=np.bool_)
+            specs["killed"] = {
+                "shape": (1, 1),
+                "maxshape": (None, 1),
+                "dtype": killed.dtype,
+            }
+
+        if "particle_type" in self.stored_fields:
+            particle_type = np.asarray([trajectory.particle_type], dtype=np.int64)
+            specs["particle_type"] = {
+                "shape": (1, 1),
+                "maxshape": (None, 1),
+                "dtype": particle_type.dtype,
+            }
+
+        return specs
+
+    def _extract_agent_sample(self, trajectory) -> Dict[str, Any]:
+        sample = {}
+
+        if "actions" in self.stored_fields:
+            sample["actions"] = trajectory.actions
+        if "log_probs" in self.stored_fields:
+            sample["log_probs"] = trajectory.log_probs
+        if "rewards" in self.stored_fields:
+            sample["rewards"] = trajectory.rewards
+        if "killed" in self.stored_fields:
+            sample["killed"] = np.asarray([trajectory.killed], dtype=np.bool_)
+        if "particle_type" in self.stored_fields:
+            sample["particle_type"] = np.asarray(
+                [trajectory.particle_type],
+                dtype=np.int64,
+            )
+
+        if "features" in self.stored_fields:
+            if getattr(trajectory, "features", None) is not None:
+                features = np.asarray(trajectory.features)
+                if features.size > 0:
+                    sample["features"] = trajectory.features
+
+        return sample
 
 
 class SimulationTrajectoryStorage(DictTrajectoryStorage):

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -1,61 +1,14 @@
 """Trajectory storages for agent and simulation data."""
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 
 from swarmrl.utils.storage_utils.core_storage import HDF5TrajectoryStorage
 
 
-class DictTrajectoryStorage(HDF5TrajectoryStorage):
-    """
-    Generic dict-based trajectory storage.
-
-    Provides:
-    - a dataset spec builder from one sample
-    - a sample extractor that returns a dict keyed like the dataset names
-    """
-
-    def __init__(
-        self,
-        out_folder: str,
-        filename: str,
-        h5_group_tag: str,
-        dataset_specs_builder: Callable[[Any], Dict[str, Dict[str, Any]]],
-        sample_extractor: Callable[[Any], Dict[str, Any]],
-        fail_if_exists: bool = False,
-    ):
-        super().__init__(
-            out_folder=out_folder,
-            filename=filename,
-            fail_if_exists=fail_if_exists,
-        )
-        self._h5_group_tag = h5_group_tag
-        self._dataset_specs_builder = dataset_specs_builder
-        self._sample_extractor = sample_extractor
-        self._dataset_keys: List[str] = []
-
-    def _get_dataset_specs(self, data_sample: Any) -> Dict[str, Dict[str, Any]]:
-        specs = self._dataset_specs_builder(data_sample)
-        self._dataset_keys = list(specs.keys())
-        return specs
-
-    def _initialize_data_holder(self) -> Dict[str, List]:
-        return {key: list() for key in self._dataset_keys}
-
-    def _accumulate_data(self, data: Any) -> None:
-        sample = self._sample_extractor(data)
-
-        if not self._data_holder:
-            self._dataset_keys = list(sample.keys())
-            self._data_holder = self._initialize_data_holder()
-
-        for key in self._dataset_keys:
-            self._data_holder[key].append(sample[key])
-
-
-class AgentTrajectoryStorage(DictTrajectoryStorage):
+class AgentTrajectoryStorage(HDF5TrajectoryStorage):
     """HDF5 storage for agent trajectory data with configurable fields."""
 
     ALLOWED_FIELDS = {
@@ -65,17 +18,17 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         "features",
         "killed",
     }
-
     PRESETS = {
-        "minimal": ["actions", "rewards"],
-        "verbose": [
+        "minimal": ("actions", "rewards"),
+        "verbose": (
             "actions",
             "log_probs",
             "rewards",
             "features",
             "killed",
-        ],
+        ),
     }
+    PRESETS["all"] = PRESETS["verbose"]
 
     def __init__(
         self,
@@ -84,6 +37,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         preset: str = "minimal",
         stored_attributes: list = None,
         fail_if_exists: bool = True,
+        write_chunk_size: int = 1,
     ):
         """
         Initialize agent trajectory storage.
@@ -103,6 +57,8 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
             Overrides preset if provided.
         fail_if_exists : bool (default=True)
             If True, raise FileExistsError when the target file already exists.
+        write_chunk_size : int (default=1)
+            Number of trajectory samples to buffer before writing to HDF5.
         """
         if stored_attributes is None:
             if preset not in self.PRESETS:
@@ -140,14 +96,13 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
         super().__init__(
             out_folder=out_folder,
             filename=f"agent_data_{particle_type}.hdf5",
-            h5_group_tag=f"Agent_{particle_type}",
-            dataset_specs_builder=self._build_agent_specs,
-            sample_extractor=self._extract_agent_sample,
             fail_if_exists=fail_if_exists,
+            write_chunk_size=write_chunk_size,
         )
+        self._h5_group_tag = f"Agent_{particle_type}"
         self.particle_type = particle_type
 
-    def _build_agent_specs(self, trajectory) -> Dict[str, Dict[str, Any]]:
+    def _get_dataset_specs(self, trajectory) -> Dict[str, Dict[str, Any]]:
         specs = {}
 
         if "actions" in self.stored_attributes:
@@ -191,7 +146,7 @@ class AgentTrajectoryStorage(DictTrajectoryStorage):
 
         return specs
 
-    def _extract_agent_sample(self, trajectory) -> Dict[str, Any]:
+    def _extract_sample(self, trajectory) -> Dict[str, Any]:
         sample = {}
 
         if "actions" in self.stored_attributes:
@@ -220,9 +175,10 @@ class AgentStorageConfig:
     storage_preset: str = "minimal"
     stored_attributes: list[str] | None = None
     fail_if_exists: bool = True
+    write_chunk_size: int = 1
 
 
-class SimulationTrajectoryStorage(DictTrajectoryStorage):
+class SimulationTrajectoryStorage(HDF5TrajectoryStorage):
     """HDF5 storage for simulation trajectory data."""
 
     def __init__(
@@ -234,14 +190,12 @@ class SimulationTrajectoryStorage(DictTrajectoryStorage):
         super().__init__(
             out_folder=out_folder,
             filename="trajectory.hdf5",
-            h5_group_tag=h5_group_tag,
-            dataset_specs_builder=self._build_simulation_specs,
-            sample_extractor=self._extract_simulation_sample,
             fail_if_exists=fail_if_exists,
         )
+        self._h5_group_tag = h5_group_tag
 
     @staticmethod
-    def _build_simulation_specs(timestep_data: Dict) -> Dict[str, Dict[str, Any]]:
+    def _get_dataset_specs(timestep_data: Dict) -> Dict[str, Dict[str, Any]]:
         n_particles = len(timestep_data.get("Ids", []))
 
         return {
@@ -278,7 +232,7 @@ class SimulationTrajectoryStorage(DictTrajectoryStorage):
         }
 
     @staticmethod
-    def _extract_simulation_sample(timestep_data: Dict) -> Dict[str, Any]:
+    def _extract_sample(timestep_data: Dict) -> Dict[str, Any]:
         return {
             "Times": timestep_data["Times"],
             "Ids": timestep_data["Ids"],

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -36,7 +36,7 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
         out_folder: str = "./Agent_Data",
         preset: str = "minimal",
         stored_attributes: list = None,
-        fail_if_exists: bool = True,
+        allow_existing_file: bool = False,
         write_chunk_size: int = 1,
     ):
         """
@@ -55,9 +55,9 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
             Explicit whitelist of attributes to store
             (e.g., ["actions", "features"]).
             Overrides preset if provided.
-        fail_if_exists : bool (default=True)
-            If True, raise FileExistsError when the target file already exists.
-            If False, allow writing to an existing HDF5 file.
+        allow_existing_file : bool (default=False)
+            If False, raise FileExistsError when the target file already exists.
+            If True, allow writing to an existing HDF5 file.
         write_chunk_size : int (default=1)
             Number of complete agent trajectory samples buffered before appending to
             HDF5. The default 1 preserves immediate writes.
@@ -98,7 +98,7 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
         super().__init__(
             out_folder=out_folder,
             filename=f"agent_data_{particle_type}.hdf5",
-            fail_if_exists=fail_if_exists,
+            allow_existing_file=allow_existing_file,
             write_chunk_size=write_chunk_size,
         )
         self._h5_group_tag = f"Agent_{particle_type}"
@@ -176,7 +176,7 @@ class AgentStorageConfig:
     out_folder: str = "./agent_data"
     storage_preset: str = "minimal"
     stored_attributes: list[str] | None = None
-    fail_if_exists: bool = True
+    allow_existing_file: bool = False
     write_chunk_size: int = 1
 
 
@@ -187,12 +187,12 @@ class SimulationTrajectoryStorage(HDF5TrajectoryStorage):
         self,
         out_folder: str = "./trajectories",
         h5_group_tag: str = "colloids",
-        fail_if_exists: bool = True,
+        allow_existing_file: bool = False,
     ):
         super().__init__(
             out_folder=out_folder,
             filename="trajectory.hdf5",
-            fail_if_exists=fail_if_exists,
+            allow_existing_file=allow_existing_file,
         )
         self._h5_group_tag = h5_group_tag
 

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -28,6 +28,7 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
             "killed",
         ),
     }
+    PRESETS["verbose"] = PRESETS["all"]
 
     def __init__(
         self,

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -58,7 +58,8 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
         fail_if_exists : bool (default=True)
             If True, raise FileExistsError when the target file already exists.
         write_chunk_size : int (default=1)
-            Number of trajectory samples to buffer before writing to HDF5.
+            Number of complete agent trajectory samples buffered before appending to
+            HDF5. The default 1 preserves immediate writes.
         """
         if stored_attributes is None:
             if preset not in self.PRESETS:

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -20,7 +20,7 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
     }
     PRESETS = {
         "minimal": ("actions", "rewards"),
-        "verbose": (
+        "all": (
             "actions",
             "log_probs",
             "rewards",
@@ -28,7 +28,6 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
             "killed",
         ),
     }
-    PRESETS["all"] = PRESETS["verbose"]
 
     def __init__(
         self,
@@ -49,7 +48,7 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
         out_folder : str (default="./Agent_Data")
             Output folder path.
         preset : str (default="minimal")
-            Preset for storage: "minimal" or "verbose".
+            Preset for storage: "minimal" or "all".
             Ignored if stored_attributes is provided.
         stored_attributes : list (default=None)
             Explicit whitelist of attributes to store
@@ -57,6 +56,7 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
             Overrides preset if provided.
         fail_if_exists : bool (default=True)
             If True, raise FileExistsError when the target file already exists.
+            If False, allow writing to an existing HDF5 file.
         write_chunk_size : int (default=1)
             Number of complete agent trajectory samples buffered before appending to
             HDF5. The default 1 preserves immediate writes.

--- a/swarmrl/utils/utils.py
+++ b/swarmrl/utils/utils.py
@@ -10,6 +10,7 @@ import typing
 import jax.numpy as jnp
 import numpy as np
 import pint
+from loguru import logger
 
 from swarmrl.components.colloid import Colloid
 
@@ -180,6 +181,10 @@ def record_trajectory(
     -------
     Dumps a hidden file to disc which is often removed after reading.
     """
+    logger.warning(
+        "Using the utils.record_trajectory method might be slow. "
+        "Use the trajectory storage for fast and efficient data storing."
+    )
     try:
         data = np.load(f".traj_data_{particle_type}.npy", allow_pickle=True)
         feature_data = data.item().get("features")


### PR DESCRIPTION
#### Summary of additions and changes

- moved trajectory writing into shared storage utilities so agent and simulation data use the same HDF5 storage path.
- `espresso.py` engine no longer writes HDF5 inline; it now uses SimulationTrajectoryStorage.
- Agent trajectory saving is configurable via `AgentTrajectoryStorage` and `AgentStorageConfig`, either by preset, or by explicitly selecting attributes  (`actions`, `rewards`, `log_probs`, `features`, `killed`).
- Agent trajectory writes can be batched with `write_chunk_size`; buffered data is written on `finalize()`.
- Trajectory outputs are safe by default: writing fails if the target file already exists unless existing-file reuse is explicitly allowed.
-  Existing HDF5 files can be reused intentionally, for example to store multiple simulation cycles in separate HDF5 groups during semi-episodic training.
- Extends test coverage for file safety, attribute validation, appending new data, vector feature persistence, and correct behavior when no new samples are available, thus no write is performed.

Parts of this PR were drafted with AI assistance, changes were reviewed and validated manually.

#### Examples

1. Store minimally

```
from swarmrl.agents.actor_critic import ActorCriticAgent
from swarmrl.utils.storage_utils import AgentStorageConfig

storage_cfg = AgentStorageConfig(
    out_folder="runs/exp_minimal",
    storage_preset="minimal",       # default behavior
    allow_existing_file=False,      # default safety
)

agent = ActorCriticAgent(
    particle_type=0,
    network=network,
    observable=observable,
    actions=actions,
    task=task,
    storage_config=storage_cfg,
)
```

2. Store all supported fields
```
storage_cfg = AgentStorageConfig(
    out_folder="runs/exp_all",
    storage_preset="all",
    allow_existing_file=False,
)
```
3. Explicit attributes to store

```
storage_cfg = AgentStorageConfig(
    out_folder="runs/exp_custom",
    stored_attributes=["actions", "rewards", "killed"],
    allow_existing_file=False,
)
```
4. Batch agent trajectory writes

```
storage_cfg = AgentStorageConfig(
    out_folder="runs/exp_batched",
    storage_preset="all",
    write_chunk_size=10,
    allow_existing_file=False,
)
```
5. Reuse an existing HDF5 file intentionally
```
storage_cfg = AgentStorageConfig(
    out_folder="runs/exp_reuse",
    storage_preset="minimal",
    allow_existing_file=True,
)
```