### PR TITLE
feat: add continuous exploration/sampling integration and tests

### DIFF
--- a/.github/workflows/espresso.yml
+++ b/.github/workflows/espresso.yml
@@ -49,6 +49,10 @@ jobs:
 
       - name: Run test suite
         run: |
+          # Ensure MODULEPATH contains the ESPResSo zen2 modules before restore.
+          # This mirrors the `module use` used in the Install step so
+          # `module restore espresso` can find the saved module.
+          test "${RUNNER_ARCH}" = "X64" && module use /cvmfs/dev.eessi.io/espresso/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all
           module restore espresso
           export NUM_PROC=$(nproc)
           export OMP_PROC_BIND=false 

--- a/CI/unit_tests/action_selection/test_action_selector.py
+++ b/CI/unit_tests/action_selection/test_action_selector.py
@@ -1,0 +1,163 @@
+"""Unit tests for ActionSelector orchestration."""
+
+import jax
+import jax.numpy as np
+import numpy as onp
+import pytest
+
+from swarmrl.action_selection.action_selector import ActionSelector
+from swarmrl.exploration_policies.exploration_policy import (
+    ContinuousExplorationPolicy,
+    DiscreteExplorationPolicy,
+)
+from swarmrl.sampling_strategies.sampling_strategy import (
+    ContinuousSamplingStrategy,
+    DiscreteSamplingStrategy,
+)
+
+
+class _DummyDiscreteSampling(DiscreteSamplingStrategy):
+    """Deterministic discrete sampler for testing."""
+
+    def __call__(self, logits, rng_key=None):
+        del rng_key
+        return np.argmax(logits, axis=-1)
+
+
+class _DummyDiscreteExploration(DiscreteExplorationPolicy):
+    """Discrete exploration that shifts indices by +1 modulo action space."""
+
+    def __call__(self, model_action, action_space_length, seed=12345):
+        del seed
+        return (model_action + 1) % action_space_length
+
+
+class _DummyContinuousSampling(ContinuousSamplingStrategy):
+    """Continuous sampler with deterministic outputs and optional log-probs."""
+
+    def __call__(
+        self,
+        logits,
+        subkey=None,
+        calculate_log_probs=True,
+        deployment_mode=False,
+    ):
+        del subkey, deployment_mode
+        actions = logits[:, :2]
+        if calculate_log_probs:
+            return actions, np.zeros((logits.shape[0],), dtype=logits.dtype)
+        return actions, None
+
+
+class _DummyContinuousExploration(ContinuousExplorationPolicy):
+    """Continuous exploration that adds +1.0 to actions."""
+
+    def __call__(self, model_actions, rng_key):
+        del rng_key
+        return model_actions + 1.0
+
+
+class TestActionSelector:
+    """Tests for action selection across discrete and continuous modes."""
+
+    def test_mode_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            ActionSelector(
+                sampling_strategy=_DummyDiscreteSampling(),
+                exploration_policy=_DummyContinuousExploration(),
+            )
+
+    def test_discrete_training_applies_exploration_and_gathers_log_probs(self):
+        selector = ActionSelector(
+            sampling_strategy=_DummyDiscreteSampling(),
+            exploration_policy=_DummyDiscreteExploration(),
+        )
+
+        logits = np.array([[1.0, 3.0, 2.0], [4.0, 1.0, 0.0]], dtype=np.float32)
+        sampling_key = jax.random.PRNGKey(0)
+        exploration_key = jax.random.PRNGKey(1)
+
+        indices, chosen_log_probs = selector.select(
+            logits=logits,
+            deployment_mode=False,
+            sampling_key=sampling_key,
+            exploration_key=exploration_key,
+        )
+
+        expected_indices = np.array([2, 1])
+        expected_log_probs = np.take_along_axis(
+            jax.nn.log_softmax(logits), expected_indices.reshape(-1, 1), axis=-1
+        ).reshape(-1)
+
+        onp.testing.assert_array_equal(indices, expected_indices)
+        onp.testing.assert_allclose(chosen_log_probs, expected_log_probs)
+
+    def test_discrete_deployment_skips_exploration(self):
+        selector = ActionSelector(
+            sampling_strategy=_DummyDiscreteSampling(),
+            exploration_policy=_DummyDiscreteExploration(),
+        )
+
+        logits = np.array([[1.0, 3.0, 2.0], [4.0, 1.0, 0.0]], dtype=np.float32)
+        sampling_key = jax.random.PRNGKey(2)
+        exploration_key = jax.random.PRNGKey(3)
+
+        indices, chosen_log_probs = selector.select(
+            logits=logits,
+            deployment_mode=True,
+            sampling_key=sampling_key,
+            exploration_key=exploration_key,
+        )
+
+        expected_indices = np.array([1, 0])
+        expected_log_probs = np.take_along_axis(
+            jax.nn.log_softmax(logits), expected_indices.reshape(-1, 1), axis=-1
+        ).reshape(-1)
+
+        onp.testing.assert_array_equal(indices, expected_indices)
+        onp.testing.assert_allclose(chosen_log_probs, expected_log_probs)
+
+    def test_continuous_training_applies_exploration_and_returns_log_probs(self):
+        selector = ActionSelector(
+            sampling_strategy=_DummyContinuousSampling(),
+            exploration_policy=_DummyContinuousExploration(),
+        )
+
+        logits = np.array([[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32)
+        sampling_key = jax.random.PRNGKey(4)
+        exploration_key = jax.random.PRNGKey(5)
+
+        actions, log_probs = selector.select(
+            logits=logits,
+            deployment_mode=False,
+            sampling_key=sampling_key,
+            exploration_key=exploration_key,
+        )
+
+        expected_actions = logits[:, :2] + 1.0
+        expected_log_probs = np.zeros((2,), dtype=np.float32)
+
+        onp.testing.assert_allclose(actions, expected_actions)
+        onp.testing.assert_allclose(log_probs, expected_log_probs)
+
+    def test_continuous_deployment_skips_exploration_and_log_probs(self):
+        selector = ActionSelector(
+            sampling_strategy=_DummyContinuousSampling(),
+            exploration_policy=_DummyContinuousExploration(),
+        )
+
+        logits = np.array([[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32)
+        sampling_key = jax.random.PRNGKey(6)
+        exploration_key = jax.random.PRNGKey(7)
+
+        actions, log_probs = selector.select(
+            logits=logits,
+            deployment_mode=True,
+            sampling_key=sampling_key,
+            exploration_key=exploration_key,
+        )
+
+        expected_actions = logits[:, :2]
+
+        onp.testing.assert_allclose(actions, expected_actions)
+        assert log_probs is None

--- a/CI/unit_tests/action_selection/test_action_selector.py
+++ b/CI/unit_tests/action_selection/test_action_selector.py
@@ -123,7 +123,9 @@ class TestActionSelector:
             exploration_policy=_DummyContinuousExploration(),
         )
 
-        logits = np.array([[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32)
+        logits = np.array(
+            [[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32
+        )
         sampling_key = jax.random.PRNGKey(4)
         exploration_key = jax.random.PRNGKey(5)
 
@@ -146,7 +148,9 @@ class TestActionSelector:
             exploration_policy=_DummyContinuousExploration(),
         )
 
-        logits = np.array([[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32)
+        logits = np.array(
+            [[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32
+        )
         sampling_key = jax.random.PRNGKey(6)
         exploration_key = jax.random.PRNGKey(7)
 

--- a/CI/unit_tests/exploration_policies/test_ornstein_uhlenbeck_exploration.py
+++ b/CI/unit_tests/exploration_policies/test_ornstein_uhlenbeck_exploration.py
@@ -58,7 +58,9 @@ class TestGlobalOUExploration:
         policy.noise = jnp.ones((4,), dtype=jnp.float32)
 
         policy.reduce_randomness(decay=0.5)
-        assert jnp.allclose(policy.noise, jnp.array([0.5, 0.5, 0.5, 0.5], dtype=jnp.float32))
+        assert jnp.allclose(
+            policy.noise, jnp.array([0.5, 0.5, 0.5, 0.5], dtype=jnp.float32)
+        )
         assert float(policy.epsilon) == pytest.approx(0.01)
 
     def test_ou_state_updates_every_call(self):

--- a/CI/unit_tests/exploration_policies/test_ornstein_uhlenbeck_exploration.py
+++ b/CI/unit_tests/exploration_policies/test_ornstein_uhlenbeck_exploration.py
@@ -1,0 +1,70 @@
+"""Tests for Ornstein-Uhlenbeck exploration policy."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from swarmrl.exploration_policies.ornstein_uhlenbeck_exploration import (
+    GlobalOUExploration,
+)
+
+
+class TestGlobalOUExploration:
+    """Unit tests for GlobalOUExploration."""
+
+    @staticmethod
+    def _build_policy(action_dimension: int = 4, epsilon: float = 1.0):
+        limits = jnp.array([[-1.0, 1.0]] * action_dimension, dtype=jnp.float32)
+        return GlobalOUExploration(
+            action_limits=limits,
+            drift=0.2,
+            volatility=0.1,
+            long_term_mean=0.0,
+            action_dimension=action_dimension,
+            epsilon=epsilon,
+        )
+
+    def test_output_shape_vector_and_batch(self):
+        policy = self._build_policy(action_dimension=4, epsilon=1.0)
+        key = jax.random.PRNGKey(0)
+
+        actions_vec = jnp.zeros((4,), dtype=jnp.float32)
+        out_vec = policy(actions_vec, key)
+        assert out_vec.shape == actions_vec.shape
+
+        actions_batch = jnp.zeros((3, 4), dtype=jnp.float32)
+        out_batch = policy(actions_batch, key)
+        assert out_batch.shape == actions_batch.shape
+
+    def test_output_is_clipped_to_action_limits(self):
+        limits = jnp.array([[-0.5, 0.5], [-0.2, 0.2], [-1.0, 1.0]], dtype=jnp.float32)
+        policy = GlobalOUExploration(
+            action_limits=limits,
+            drift=0.5,
+            volatility=2.0,
+            long_term_mean=0.0,
+            action_dimension=3,
+            epsilon=1.0,
+        )
+        actions = jnp.zeros((5, 3), dtype=jnp.float32)
+        out = policy(actions, jax.random.PRNGKey(1))
+
+        assert jnp.all(out[:, 0] >= -0.5) and jnp.all(out[:, 0] <= 0.5)
+        assert jnp.all(out[:, 1] >= -0.2) and jnp.all(out[:, 1] <= 0.2)
+        assert jnp.all(out[:, 2] >= -1.0) and jnp.all(out[:, 2] <= 1.0)
+
+    def test_reduce_randomness_decays_noise_and_epsilon_with_floor(self):
+        policy = self._build_policy(action_dimension=4, epsilon=0.02)
+        policy.noise = jnp.ones((4,), dtype=jnp.float32)
+
+        policy.reduce_randomness(decay=0.5)
+        assert jnp.allclose(policy.noise, jnp.array([0.5, 0.5, 0.5, 0.5], dtype=jnp.float32))
+        assert float(policy.epsilon) == pytest.approx(0.01)
+
+    def test_ou_state_updates_every_call(self):
+        policy = self._build_policy(action_dimension=4, epsilon=1.0)
+        before = policy.noise
+        _ = policy(jnp.zeros((4,), dtype=jnp.float32), jax.random.PRNGKey(2))
+        after = policy.noise
+
+        assert not jnp.allclose(before, after)

--- a/CI/unit_tests/networks/test_flax_network.py
+++ b/CI/unit_tests/networks/test_flax_network.py
@@ -9,6 +9,7 @@ import flax.linen as nn
 import jax
 import numpy as np
 import optax
+import pytest
 
 import swarmrl as srl
 from swarmrl.agents.actor_critic import ActorCriticAgent
@@ -202,3 +203,75 @@ class TestFlaxNetwork:
                 path for path in Path(temp_directory).iterdir() if path.is_file()
             ]
             np.testing.assert_equal(len(saved_models), 4)
+
+    def test_mode_mismatch_raises(self):
+        class ContinuousNetwork(nn.Module):
+            @nn.compact
+            def __call__(self, x):
+                x = nn.Dense(features=32)(x)
+                x = nn.relu(x)
+                y = nn.Dense(features=1)(x)
+                x = nn.Dense(features=6)(x)
+                return x, y
+
+        with pytest.raises(ValueError):
+            FlaxModel(
+                flax_model=ContinuousNetwork(),
+                optimizer=optax.adam(learning_rate=0.001),
+                input_shape=(2,),
+                sampling_strategy=srl.sampling_strategies.ContinuousGaussianDistribution(
+                    action_dimension=3
+                ),
+                exploration_policy=srl.exploration_policies.RandomExploration(
+                    probability=0.1
+                ),
+            )
+
+    def test_compute_action_continuous_training_and_deployment(self):
+        class ContinuousNetwork(nn.Module):
+            @nn.compact
+            def __call__(self, x):
+                x = nn.Dense(features=64)(x)
+                x = nn.relu(x)
+                y = nn.Dense(features=1)(x)
+                x = nn.Dense(features=6)(x)
+                return x, y
+
+        limits = np.array([[-1.0, 1.0], [-0.5, 0.5], [-2.0, 2.0]], dtype=np.float32)
+
+        # Training mode: compute log-probs.
+        train_model = FlaxModel(
+            flax_model=ContinuousNetwork(),
+            optimizer=optax.adam(learning_rate=0.001),
+            input_shape=(2,),
+            sampling_strategy=srl.sampling_strategies.ContinuousGaussianDistribution(
+                action_dimension=3, action_limits=limits
+            ),
+            exploration_policy=srl.exploration_policies.GlobalOUExploration(
+                action_limits=limits, action_dimension=3, epsilon=1.0
+            ),
+            deployment_mode=False,
+        )
+        input_data = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+        actions, log_probs = train_model.compute_action(input_data)
+        assert actions.shape == (2, 3)
+        assert log_probs is not None
+        assert log_probs.shape == (2,)
+
+        # Deployment mode: deterministic Gaussian output, no log-probs.
+        deploy_model = FlaxModel(
+            flax_model=ContinuousNetwork(),
+            optimizer=optax.adam(learning_rate=0.001),
+            input_shape=(2,),
+            sampling_strategy=srl.sampling_strategies.ContinuousGaussianDistribution(
+                action_dimension=3, action_limits=limits
+            ),
+            exploration_policy=srl.exploration_policies.GlobalOUExploration(
+                action_limits=limits, action_dimension=3, epsilon=1.0
+            ),
+            deployment_mode=True,
+        )
+        deploy_model.model_state = train_model.model_state
+        deploy_actions, deploy_log_probs = deploy_model.compute_action(input_data)
+        assert deploy_actions.shape == (2, 3)
+        assert deploy_log_probs is None

--- a/CI/unit_tests/sampling_strategies/test_gaussian.py
+++ b/CI/unit_tests/sampling_strategies/test_gaussian.py
@@ -1,0 +1,65 @@
+"""Tests for continuous Gaussian sampling strategy."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from swarmrl.sampling_strategies.gaussian_distribution import (
+    ContinuousGaussianDistribution,
+)
+
+
+class TestContinuousGaussianDistribution:
+    """Unit tests for ContinuousGaussianDistribution."""
+
+    def test_logits_shape_validation(self):
+        sampler = ContinuousGaussianDistribution(action_dimension=3)
+        bad_logits = jnp.zeros((2, 5), dtype=jnp.float32)
+
+        with pytest.raises(ValueError):
+            sampler(bad_logits, subkey=jax.random.PRNGKey(0))
+
+    def test_returns_actions_and_log_probs_in_training_mode(self):
+        sampler = ContinuousGaussianDistribution(action_dimension=3)
+        logits = jnp.zeros((4, 6), dtype=jnp.float32)
+
+        actions, log_probs = sampler(
+            logits,
+            subkey=jax.random.PRNGKey(1),
+            calculate_log_probs=True,
+            deployment_mode=False,
+        )
+
+        assert actions.shape == (4, 3)
+        assert log_probs is not None
+        assert log_probs.shape == (4,)
+
+    def test_returns_none_log_probs_in_deployment_mode(self):
+        sampler = ContinuousGaussianDistribution(action_dimension=3)
+        logits = jnp.zeros((3, 6), dtype=jnp.float32)
+
+        actions, log_probs = sampler(
+            logits,
+            subkey=jax.random.PRNGKey(2),
+            calculate_log_probs=True,
+            deployment_mode=True,
+        )
+
+        assert actions.shape == (3, 3)
+        assert log_probs is None
+
+    def test_action_limits_are_respected(self):
+        limits = jnp.array([[-0.3, 0.3], [-0.2, 0.2], [-1.0, 1.0]], dtype=jnp.float32)
+        sampler = ContinuousGaussianDistribution(action_dimension=3, action_limits=limits)
+        logits = jnp.zeros((16, 6), dtype=jnp.float32)
+
+        actions, _ = sampler(
+            logits,
+            subkey=jax.random.PRNGKey(3),
+            calculate_log_probs=False,
+            deployment_mode=False,
+        )
+
+        assert jnp.all(actions[:, 0] >= -0.3) and jnp.all(actions[:, 0] <= 0.3)
+        assert jnp.all(actions[:, 1] >= -0.2) and jnp.all(actions[:, 1] <= 0.2)
+        assert jnp.all(actions[:, 2] >= -1.0) and jnp.all(actions[:, 2] <= 1.0)

--- a/CI/unit_tests/sampling_strategies/test_gaussian.py
+++ b/CI/unit_tests/sampling_strategies/test_gaussian.py
@@ -50,7 +50,9 @@ class TestContinuousGaussianDistribution:
 
     def test_action_limits_are_respected(self):
         limits = jnp.array([[-0.3, 0.3], [-0.2, 0.2], [-1.0, 1.0]], dtype=jnp.float32)
-        sampler = ContinuousGaussianDistribution(action_dimension=3, action_limits=limits)
+        sampler = ContinuousGaussianDistribution(
+            action_dimension=3, action_limits=limits
+        )
         logits = jnp.zeros((16, 6), dtype=jnp.float32)
 
         actions, _ = sampler(

--- a/CI/unit_tests/sampling_strategies/test_sampling_strategy.py
+++ b/CI/unit_tests/sampling_strategies/test_sampling_strategy.py
@@ -7,6 +7,13 @@ import numpy as np
 from swarmrl.sampling_strategies.sampling_strategy import SamplingStrategy
 
 
+class _DummySamplingStrategy(SamplingStrategy):
+    """Concrete test double for abstract SamplingStrategy."""
+
+    def __call__(self, logits):
+        return logits
+
+
 class TestSamplingStrategy:
     """
     Test suite for the sampling strategy parent.
@@ -17,7 +24,7 @@ class TestSamplingStrategy:
         """
         Prepare some initial attributes.
         """
-        cls.strategy = SamplingStrategy()
+        cls.strategy = _DummySamplingStrategy()
 
     def test_compute_entropy(self):
         """

--- a/swarmrl/__init__.py
+++ b/swarmrl/__init__.py
@@ -5,6 +5,7 @@ __init__ file for the swarmrl package.
 from loguru import logger as _loguru_logger
 
 from swarmrl import (
+    action_selection,
     agents,
     checkpointers,
     components,
@@ -30,6 +31,7 @@ _loguru_logger.disable("swarmrl")
 __all__ = [
     espresso.__name__,
     utils.__name__,
+    action_selection.__name__,
     losses.__name__,
     checkpointers.__name__,
     components.__name__,

--- a/swarmrl/action_selection/__init__.py
+++ b/swarmrl/action_selection/__init__.py
@@ -1,0 +1,5 @@
+"""Action selection module."""
+
+from swarmrl.action_selection.action_selector import ActionSelector
+
+__all__ = [ActionSelector.__name__]

--- a/swarmrl/action_selection/action_selector.py
+++ b/swarmrl/action_selection/action_selector.py
@@ -1,0 +1,92 @@
+"""Action selection orchestration for discrete and continuous stacks."""
+
+import jax
+import jax.numpy as np
+
+from swarmrl.exploration_policies.exploration_policy import (
+    ContinuousExplorationPolicy,
+    DiscreteExplorationPolicy,
+    ExplorationPolicy,
+)
+from swarmrl.sampling_strategies.sampling_strategy import (
+    ContinuousSamplingStrategy,
+    DiscreteSamplingStrategy,
+    SamplingStrategy,
+)
+
+
+class ActionSelector:
+    """Compose sampling + exploration for action selection."""
+
+    def __init__(
+        self,
+        sampling_strategy: SamplingStrategy,
+        exploration_policy: ExplorationPolicy,
+    ) -> None:
+        self.sampling_strategy = sampling_strategy
+        self.exploration_policy = exploration_policy
+        self.mode = self._infer_mode(sampling_strategy, exploration_policy)
+
+    @staticmethod
+    def _infer_mode(
+        sampling_strategy: SamplingStrategy,
+        exploration_policy: ExplorationPolicy,
+    ) -> str:
+        sampling_is_discrete = isinstance(sampling_strategy, DiscreteSamplingStrategy)
+        sampling_is_continuous = isinstance(
+            sampling_strategy, ContinuousSamplingStrategy
+        )
+        explore_is_discrete = isinstance(exploration_policy, DiscreteExplorationPolicy)
+        explore_is_continuous = isinstance(
+            exploration_policy, ContinuousExplorationPolicy
+        )
+
+        if sampling_is_discrete and explore_is_discrete:
+            return "discrete"
+        if sampling_is_continuous and explore_is_continuous:
+            return "continuous"
+
+        raise ValueError(
+            "Sampling strategy and exploration policy modes must match. "
+            f"Got sampling={type(sampling_strategy).__name__}, "
+            f"exploration={type(exploration_policy).__name__}."
+        )
+
+    def select(
+        self,
+        logits: np.ndarray,
+        deployment_mode: bool,
+        sampling_key,
+        exploration_key,
+    ) -> tuple:
+        if self.mode == "discrete":
+            indices = self.sampling_strategy(logits, rng_key=sampling_key)
+            log_probs = jax.nn.log_softmax(logits)
+
+            if not deployment_mode:
+                exploration_seed = int(
+                    jax.random.randint(exploration_key, (), 0, 2**31 - 1)
+                )
+                indices = self.exploration_policy(
+                    indices, logits.shape[-1], exploration_seed
+                )
+            expanded_indices = np.expand_dims(indices, axis=-1)
+            chosen_log_probs = np.take_along_axis(log_probs, expanded_indices, axis=-1)
+            chosen_log_probs = np.squeeze(chosen_log_probs, axis=-1)
+
+            return indices, chosen_log_probs
+
+        if self.mode == "continuous":
+            calculate_log_probs = not deployment_mode
+            sampled_actions, log_probs = self.sampling_strategy(
+                logits=logits,
+                subkey=sampling_key,
+                calculate_log_probs=calculate_log_probs,
+                deployment_mode=deployment_mode,
+            )
+            actions = sampled_actions
+            if not deployment_mode:
+                actions = self.exploration_policy(sampled_actions, exploration_key)
+            return actions, log_probs
+
+        raise ValueError(f"Unsupported action selection mode: {self.mode}")

--- a/swarmrl/exploration_policies/__init__.py
+++ b/swarmrl/exploration_policies/__init__.py
@@ -2,7 +2,20 @@
 Module for exploration policies.
 """
 
-from swarmrl.exploration_policies.exploration_policy import ExplorationPolicy
+from swarmrl.exploration_policies.exploration_policy import (
+    ContinuousExplorationPolicy,
+    DiscreteExplorationPolicy,
+    ExplorationPolicy,
+)
+from swarmrl.exploration_policies.ornstein_uhlenbeck_exploration import (
+    GlobalOUExploration,
+)
 from swarmrl.exploration_policies.random_exploration import RandomExploration
 
-__all__ = [ExplorationPolicy.__name__, RandomExploration.__name__]
+__all__ = [
+    ExplorationPolicy.__name__,
+    DiscreteExplorationPolicy.__name__,
+    ContinuousExplorationPolicy.__name__,
+    RandomExploration.__name__,
+    GlobalOUExploration.__name__,
+]

--- a/swarmrl/exploration_policies/exploration_policy.py
+++ b/swarmrl/exploration_policies/exploration_policy.py
@@ -2,16 +2,34 @@
 Parent class for exploration modules.
 """
 
+from abc import ABC, abstractmethod
+from typing import Any
+
+import jax
 import jax.numpy as np
 
 
-class ExplorationPolicy:
+class ExplorationPolicy(ABC):
     """
     Parent class for exploration policies.
     """
 
+    @abstractmethod
+    def __call__(self, *args: Any, **kwargs: Any) -> np.ndarray:
+        """
+        Apply exploration to model actions.
+        """
+        raise NotImplementedError
+
+
+class DiscreteExplorationPolicy(ExplorationPolicy, ABC):
+    """
+    Parent class for discrete exploration policies.
+    """
+
+    @abstractmethod
     def __call__(
-        self, model_actions: np.ndarray, action_space_length: int
+        self, model_actions: np.ndarray, action_space_length: int, seed: Any
     ) -> np.ndarray:
         """
         Return an index associated with the chosen action.
@@ -29,5 +47,32 @@ class ExplorationPolicy:
         action : np.ndarray
                 Action chosen after the exploration module has operated for
                 each colloid.
+        """
+        raise NotImplementedError
+
+
+class ContinuousExplorationPolicy(ExplorationPolicy, ABC):
+    """
+    Parent class for continuous exploration policies.
+    """
+
+    @abstractmethod
+    def __call__(
+        self, model_actions: np.ndarray, rng_key: jax.random.PRNGKey
+    ) -> np.ndarray:
+        """
+        Return an action value
+
+        Parameters
+        ----------
+        model_actions : np.ndarray (n_colloids,)
+                Action chosen by the model for each colloid.
+        rng_key : jax.random.PRNGKey
+                Key for jax.random module
+
+        Returns
+        -------
+        action : np.ndarray
+                Action chosen after the exploration module has operated.
         """
         raise NotImplementedError

--- a/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
+++ b/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
@@ -1,0 +1,125 @@
+"""
+Global Ornstein-Uhlenbeck (OU) exploration for continuous actions.
+"""
+
+from typing import Any
+
+import jax
+import jax.numpy as np
+
+from swarmrl.exploration_policies.exploration_policy import ContinuousExplorationPolicy
+
+
+class GlobalOUExploration(ContinuousExplorationPolicy):
+    """
+    Adds temporally-correlated OU noise to continuous model actions,
+    as defined here https://en.wikipedia.org/wiki/Ornstein–Uhlenbeck_process#Definition:
+    dx_t = theta * (mu - x_t) * dt + sigma * dW_t. For simplicity dt=1 is assumed.
+
+    Parameters/Symbols:
+    - theta: Mean-reversion speed.
+    - mu: Long-term mean (the value the noise settles around).
+    - sigma: Volatility / scaling factor.
+    - dW_t: Wiener process increment (Standard Brownian Motion).
+        In discrete time with dt=1, dW_t is sampled from N(0, 1).
+
+    Epsilon gating is applied per action dimension.
+    For an action vector like ``[a, b, c, ...]``, each component is
+    perturbed independently with probability ``epsilon`` at every step.
+    The OU internal state is still updated every step, even when a component
+    is not applied to the output action in that step.
+
+    """
+
+    def __init__(
+        self,
+        action_limits: Any,
+        drift: float = 0.1,
+        volatility: float = 0.1,
+        long_term_mean: float = 0.0,
+        action_dimension: int = 3,
+        epsilon: float = 1.0,
+    ) -> None:
+        """
+        Initialize the OU exploration process.
+
+        Parameters
+        ----------
+        action_limits : array-like, shape (action_dimension, 2)
+            Per-action lower/upper bounds used for clipping and noise scaling.
+        drift : float
+            Mean-reversion strength (theta). Must be > 0.
+        volatility : float
+            Diffusion scale (sigma).
+        long_term_mean : float
+            Long-term mean (mu) of the OU process.
+        action_dimension : int
+            Number of continuous action dimensions.
+        epsilon : float
+            Probability of applying OU noise in a step. Must be > 0.
+        """
+        self.drift: float = float(drift)
+        self.volatility: float = float(volatility)
+        self.long_term_mean: np.ndarray = np.asarray(long_term_mean, dtype=np.float32)
+        self.action_dimension: int = int(action_dimension)
+        self.action_limits: np.ndarray = np.asarray(action_limits, dtype=np.float32)
+        self.noise: np.ndarray = np.zeros(self.action_dimension, dtype=np.float32)
+        self.epsilon: np.ndarray = np.asarray(epsilon, dtype=np.float32)
+
+        if self.drift <= 0:
+            raise ValueError("drift needs to be greater than 0")
+        if float(self.epsilon) <= 0:
+            raise ValueError("epsilon needs to be greater than 0")
+
+        if self.action_limits.shape != (self.action_dimension, 2):
+            raise ValueError(
+                f"action_limits shape is {self.action_limits.shape}, should be"
+                f" {(self.action_dimension, 2)}."
+            )
+
+    def reduce_randomness(self, decay: float = 0.95) -> None:
+        """
+        Reduce OU state magnitude and epsilon (called every 10 episodes by trainer).
+        """
+        decay = np.asarray(decay, dtype=np.float32)
+        self.noise = self.noise * decay
+        self.epsilon = np.maximum(self.epsilon * decay, np.float32(0.01))
+
+    def __call__(
+        self, model_actions: np.ndarray, rng_key: jax.random.PRNGKey
+    ) -> np.ndarray:
+        """
+        Add OU noise to model actions.
+
+        OU state is always updated; epsilon only gates whether noise is applied
+        to the current action output. Gating is dimension-wise (independent per
+        action component), not one shared gate for the whole action vector.
+        """
+        model_actions = np.asarray(model_actions, dtype=np.float32)
+        key_normal, key_uniform = jax.random.split(rng_key)
+
+        value_range = self.action_limits[:, 1] - self.action_limits[:, 0]
+
+        # Update OU state.
+        long_term_noise_shift = self.drift * (self.long_term_mean - self.noise)
+        random_noise = (
+            self.volatility
+            * value_range
+            * jax.random.normal(key_normal, shape=self.noise.shape, dtype=np.float32)
+        )
+
+        self.noise = self.noise + long_term_noise_shift + random_noise
+
+        # Decide whether to apply exploration in this step (per action dimension).
+        should_explore = (
+            jax.random.uniform(key_uniform, shape=self.noise.shape, dtype=np.float32)
+            < self.epsilon
+        ).astype(np.float32)
+
+        noise_to_apply = self.noise * should_explore
+        if model_actions.ndim > 1:
+            noise_to_apply = noise_to_apply.reshape(1, -1)
+
+        actions = model_actions + noise_to_apply
+        actions = np.clip(actions, self.action_limits[:, 0], self.action_limits[:, 1])
+        return actions

--- a/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
+++ b/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
@@ -16,6 +16,13 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
     as defined here https://en.wikipedia.org/wiki/Ornstein–Uhlenbeck_process#Definition:
     dx_t = theta * (mu - x_t) * dt + sigma * dW_t. For simplicity dt=1 is assumed.
 
+    References
+    ----------
+    1. G. E. Uhlenbeck and L. S. Ornstein, "On the theory of the Brownian
+       motion", Phys. Rev. 36, 823-841 (1930).
+    2. T. P. Lillicrap et al., "Continuous control with deep reinforcement
+       learning", arXiv:1509.02971 (2015), which uses OU noise for exploration.
+
     Parameters/Symbols:
     - theta: Mean-reversion speed.
     - mu: Long-term mean (the value the noise settles around).
@@ -39,6 +46,7 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         long_term_mean: float = 0.0,
         action_dimension: int = 3,
         epsilon: float = 1.0,
+        float_precision: np.dtype = np.float32,
     ) -> None:
         """
         Initialize the OU exploration process.
@@ -57,14 +65,21 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
             Number of continuous action dimensions.
         epsilon : float
             Probability of applying OU noise in a step. Must be > 0.
+        float_precision : np.dtype
+            Float precision to use for computations.
         """
         self.drift: float = float(drift)
         self.volatility: float = float(volatility)
-        self.long_term_mean: np.ndarray = np.asarray(long_term_mean, dtype=np.float32)
+        self.long_term_mean: np.ndarray = np.asarray(
+            long_term_mean, dtype=float_precision
+        )
         self.action_dimension: int = int(action_dimension)
-        self.action_limits: np.ndarray = np.asarray(action_limits, dtype=np.float32)
-        self.noise: np.ndarray = np.zeros(self.action_dimension, dtype=np.float32)
-        self.epsilon: np.ndarray = np.asarray(epsilon, dtype=np.float32)
+        self.action_limits: np.ndarray = np.asarray(
+            action_limits, dtype=float_precision
+        )
+        self.noise: np.ndarray = np.zeros(self.action_dimension, dtype=float_precision)
+        self.epsilon: np.ndarray = np.asarray(epsilon, dtype=float_precision)
+        self.float_precision: np.dtype = float_precision
 
         if self.drift <= 0:
             raise ValueError("drift needs to be greater than 0")
@@ -81,9 +96,9 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         """
         Reduce OU state magnitude and epsilon (called every 10 episodes by trainer).
         """
-        decay = np.asarray(decay, dtype=np.float32)
+        decay = np.asarray(decay, dtype=self.float_precision)
         self.noise = self.noise * decay
-        self.epsilon = np.maximum(self.epsilon * decay, np.float32(0.01))
+        self.epsilon = np.maximum(self.epsilon * decay, self.float_precision(0.01))
 
     def __call__(
         self, model_actions: np.ndarray, rng_key: jax.random.PRNGKey
@@ -95,7 +110,7 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         to the current action output. Gating is dimension-wise (independent per
         action component), not one shared gate for the whole action vector.
         """
-        model_actions = np.asarray(model_actions, dtype=np.float32)
+        model_actions = np.asarray(model_actions, dtype=self.float_precision)
         key_normal, key_uniform = jax.random.split(rng_key)
 
         value_range = self.action_limits[:, 1] - self.action_limits[:, 0]
@@ -105,16 +120,20 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         random_noise = (
             self.volatility
             * value_range
-            * jax.random.normal(key_normal, shape=self.noise.shape, dtype=np.float32)
+            * jax.random.normal(
+                key_normal, shape=self.noise.shape, dtype=self.float_precision
+            )
         )
 
         self.noise = self.noise + long_term_noise_shift + random_noise
 
         # Decide whether to apply exploration in this step (per action dimension).
         should_explore = (
-            jax.random.uniform(key_uniform, shape=self.noise.shape, dtype=np.float32)
+            jax.random.uniform(
+                key_uniform, shape=self.noise.shape, dtype=self.float_precision
+            )
             < self.epsilon
-        ).astype(np.float32)
+        ).astype(self.float_precision)
 
         noise_to_apply = self.noise * should_explore
         if model_actions.ndim > 1:

--- a/swarmrl/exploration_policies/random_exploration.py
+++ b/swarmrl/exploration_policies/random_exploration.py
@@ -2,16 +2,15 @@
 Random exploration module.
 """
 
-from abc import ABC
 from functools import partial
 
 import jax
 import jax.numpy as np
 
-from swarmrl.exploration_policies.exploration_policy import ExplorationPolicy
+from swarmrl.exploration_policies.exploration_policy import DiscreteExplorationPolicy
 
 
-class RandomExploration(ExplorationPolicy, ABC):
+class RandomExploration(DiscreteExplorationPolicy):
     """
     Perform exploration by random moves.
     """

--- a/swarmrl/networks/flax_network.py
+++ b/swarmrl/networks/flax_network.py
@@ -16,19 +16,12 @@ from flax.training.train_state import TrainState
 from loguru import logger
 from optax._src.base import GradientTransformation
 
-from swarmrl.exploration_policies.exploration_policy import (
-    ContinuousExplorationPolicy,
-    DiscreteExplorationPolicy,
-    ExplorationPolicy,
-)
+from swarmrl.action_selection.action_selector import ActionSelector
+from swarmrl.exploration_policies.exploration_policy import ExplorationPolicy
 from swarmrl.exploration_policies.random_exploration import RandomExploration
 from swarmrl.networks.network import Network
 from swarmrl.sampling_strategies.gumbel_distribution import GumbelDistribution
-from swarmrl.sampling_strategies.sampling_strategy import (
-    ContinuousSamplingStrategy,
-    DiscreteSamplingStrategy,
-    SamplingStrategy,
-)
+from swarmrl.sampling_strategies.sampling_strategy import SamplingStrategy
 
 
 class FlaxModel(Network, ABC):
@@ -78,7 +71,6 @@ class FlaxModel(Network, ABC):
             rng_key = int(onp.random.randint(0, 2**31 - 1))
         self._rng_key = jax.random.PRNGKey(int(rng_key))
         self.sampling_strategy = sampling_strategy
-        self._sample_mode = self._infer_sampling_mode(sampling_strategy)
         self.model = flax_model
         self.apply_fn = jax.jit(
             jax.vmap(self.model.apply, in_axes=(None, 0))
@@ -89,38 +81,20 @@ class FlaxModel(Network, ABC):
 
         self.deployment_mode = deployment_mode
 
+        self.exploration_policy = exploration_policy
+        self.action_selector = ActionSelector(
+            sampling_strategy=self.sampling_strategy,
+            exploration_policy=self.exploration_policy,
+        )
+
         if not deployment_mode:
             self.optimizer = optimizer
-            self.exploration_policy = exploration_policy
-            self._exploration_mode = self._infer_exploration_mode(exploration_policy)
-            if self._sample_mode != self._exploration_mode:
-                raise ValueError(
-                    "Sampling strategy and exploration policy modes must match. "
-                    f"Got sampling='{self._sample_mode}' and "
-                    f"exploration='{self._exploration_mode}'."
-                )
 
             # initialize the model state
             self._rng_key, init_subkey = jax.random.split(self._rng_key)
             self.model_state = self._create_train_state(init_subkey)
 
             self.epoch_count = 0
-
-    @staticmethod
-    def _infer_exploration_mode(exploration_policy: ExplorationPolicy) -> str:
-        if isinstance(exploration_policy, ContinuousExplorationPolicy):
-            return "continuous"
-        if isinstance(exploration_policy, DiscreteExplorationPolicy):
-            return "discrete"
-        return "discrete"
-
-    @staticmethod
-    def _infer_sampling_mode(sampling_strategy: SamplingStrategy) -> str:
-        if isinstance(sampling_strategy, ContinuousSamplingStrategy):
-            return "continuous"
-        if isinstance(sampling_strategy, DiscreteSamplingStrategy):
-            return "discrete"
-        return "discrete"
 
     def _next_rng_key(self):
         """Split and advance internal RNG state, returning a fresh subkey."""
@@ -226,49 +200,18 @@ class FlaxModel(Network, ABC):
                 {"params": self.model_state["params"]}, np.array(observables)
             )
         logger.debug(f"{logits=}")  # (n_colloids, n_actions)
-
-        if self._sample_mode == "discrete":
-            # Compute discrete action indices.
-            sampling_key = self._next_rng_key()
-            indices = self.sampling_strategy(logits, rng_key=sampling_key)
-            # Add a small value to the log_probs to avoid log(0) errors.
-            eps = 1e-8
-            log_probs = np.log(jax.nn.softmax(logits) + eps)
-
-            if not self.deployment_mode:
-                exploration_key = self._next_rng_key()
-                exploration_seed = int(
-                    jax.random.randint(exploration_key, (), 0, 2**31 - 1)
-                )
-                indices = self.exploration_policy(
-                    indices, logits.shape[-1], exploration_seed
-                )
-            chosen_log_probs = np.take_along_axis(
-                log_probs, indices.reshape(-1, 1), axis=1
-            ).reshape(-1)
-
-            return (indices, chosen_log_probs)
-
-        elif self._sample_mode == "continuous":
-            # Continuous path: sampling strategy outputs action values directly.
-            sampling_key = self._next_rng_key()
+        sampling_key = self._next_rng_key()
+        exploration_key = jax.random.PRNGKey(0)
+        if not self.deployment_mode:
             exploration_key = self._next_rng_key()
-            calculate_log_probs = not self.deployment_mode
-            sampled_actions, log_probs = self.sampling_strategy(
-                logits=logits,
-                subkey=sampling_key,
-                calculate_log_probs=calculate_log_probs,
-                deployment_mode=self.deployment_mode,
-            )
 
-            actions = sampled_actions
-            if not self.deployment_mode:
-                actions = self.exploration_policy(
-                    model_actions=sampled_actions, rng_key=exploration_key
-                )
-            return actions, log_probs
-        else:
-            raise ValueError(f"Unsupported sampling mode: {self._sample_mode}")
+        actions_or_indices, log_probs = self.action_selector.select(
+            logits=logits,
+            deployment_mode=self.deployment_mode,
+            sampling_key=sampling_key,
+            exploration_key=exploration_key,
+        )
+        return actions_or_indices, log_probs
 
     def export_model(self, filename: str = "model", directory: str = "Models"):
         """

--- a/swarmrl/networks/flax_network.py
+++ b/swarmrl/networks/flax_network.py
@@ -16,11 +16,19 @@ from flax.training.train_state import TrainState
 from loguru import logger
 from optax._src.base import GradientTransformation
 
-from swarmrl.exploration_policies.exploration_policy import ExplorationPolicy
+from swarmrl.exploration_policies.exploration_policy import (
+    ContinuousExplorationPolicy,
+    DiscreteExplorationPolicy,
+    ExplorationPolicy,
+)
 from swarmrl.exploration_policies.random_exploration import RandomExploration
 from swarmrl.networks.network import Network
 from swarmrl.sampling_strategies.gumbel_distribution import GumbelDistribution
-from swarmrl.sampling_strategies.sampling_strategy import SamplingStrategy
+from swarmrl.sampling_strategies.sampling_strategy import (
+    ContinuousSamplingStrategy,
+    DiscreteSamplingStrategy,
+    SamplingStrategy,
+)
 
 
 class FlaxModel(Network, ABC):
@@ -55,16 +63,22 @@ class FlaxModel(Network, ABC):
                 cross-compatibility is not assured.
         input_shape : tuple
                 Shape of the NN input.
+        exploration_policy : ExplorationPolicy
+                Exploration module. Must match the sampling strategy mode
+                (discrete/discrete or continuous/continuous).
+        sampling_strategy : SamplingStrategy
+                Strategy that samples actions from network outputs.
         rng_key : int
-                Key to seed the model with. Default is a randomly generated key but
-                the parameter is here for testing purposes.
+                Integer seed used to initialize the model's internal JAX PRNG key.
         deployment_mode : bool
                 If true, the model is a shell for the network and nothing else. No
                 training can be performed, this is only used in deployment.
         """
         if rng_key is None:
-            rng_key = onp.random.randint(0, 1027465782564)
+            rng_key = int(onp.random.randint(0, 2**31 - 1))
+        self._rng_key = jax.random.PRNGKey(int(rng_key))
         self.sampling_strategy = sampling_strategy
+        self._sample_mode = self._infer_sampling_mode(sampling_strategy)
         self.model = flax_model
         self.apply_fn = jax.jit(
             jax.vmap(self.model.apply, in_axes=(None, 0))
@@ -73,16 +87,45 @@ class FlaxModel(Network, ABC):
         self.input_shape = input_shape
         self.model_state = None
 
+        self.deployment_mode = deployment_mode
+
         if not deployment_mode:
             self.optimizer = optimizer
             self.exploration_policy = exploration_policy
+            self._exploration_mode = self._infer_exploration_mode(exploration_policy)
+            if self._sample_mode != self._exploration_mode:
+                raise ValueError(
+                    "Sampling strategy and exploration policy modes must match. "
+                    f"Got sampling='{self._sample_mode}' and "
+                    f"exploration='{self._exploration_mode}'."
+                )
 
             # initialize the model state
-            init_rng = jax.random.PRNGKey(rng_key)
-            _, subkey = jax.random.split(init_rng)
-            self.model_state = self._create_train_state(subkey)
+            self._rng_key, init_subkey = jax.random.split(self._rng_key)
+            self.model_state = self._create_train_state(init_subkey)
 
             self.epoch_count = 0
+
+    @staticmethod
+    def _infer_exploration_mode(exploration_policy: ExplorationPolicy) -> str:
+        if isinstance(exploration_policy, ContinuousExplorationPolicy):
+            return "continuous"
+        if isinstance(exploration_policy, DiscreteExplorationPolicy):
+            return "discrete"
+        return "discrete"
+
+    @staticmethod
+    def _infer_sampling_mode(sampling_strategy: SamplingStrategy) -> str:
+        if isinstance(sampling_strategy, ContinuousSamplingStrategy):
+            return "continuous"
+        if isinstance(sampling_strategy, DiscreteSamplingStrategy):
+            return "discrete"
+        return "discrete"
+
+    def _next_rng_key(self):
+        """Split and advance internal RNG state, returning a fresh subkey."""
+        self._rng_key, subkey = jax.random.split(self._rng_key)
+        return subkey
 
     def _create_custom_train_state(self, optimizer: dict):
         """
@@ -122,9 +165,7 @@ class FlaxModel(Network, ABC):
         """
         Initialize the neural network.
         """
-        rng_key = onp.random.randint(0, 1027465782564)
-        init_rng = jax.random.PRNGKey(rng_key)
-        _, subkey = jax.random.split(init_rng)
+        subkey = self._next_rng_key()
         self.model_state = self._create_train_state(subkey)
 
     def update_model(self, grads):
@@ -150,7 +191,7 @@ class FlaxModel(Network, ABC):
 
     def compute_action(self, observables: List):
         """
-        Compute and action from the action space.
+        Compute an action from the action space.
 
         This method computes an action on all colloids of the relevant type.
 
@@ -161,11 +202,19 @@ class FlaxModel(Network, ABC):
 
         Returns
         -------
-        tuple : (np.ndarray, np.ndarray)
-                The first element is an array of indices corresponding to the action
-                taken by the agent. The value is bounded between 0 and the number of
-                output neurons. The second element is an array of the corresponding
-                log_probs (i.e. the output of the network put through a softmax).
+        tuple : (np.ndarray, Optional[np.ndarray])
+                Discrete mode:
+                    ``(indices, chosen_log_probs)``, where chosen log-probs
+                    (softmaxed network output) are gathered from ``log softmax(logits)``
+                    at the selected indices that correspond to the action taken by the
+                    agent. The value is bounded between 0 and  the number of output
+                    neurons.
+
+                Continuous mode:
+                    ``(actions, log_probs)``, where ``log_probs`` are returned
+                    by the continuous sampling strategy. In deployment mode,
+                    these can be ``None``.
+
         """
         # Compute state
         try:
@@ -178,19 +227,48 @@ class FlaxModel(Network, ABC):
             )
         logger.debug(f"{logits=}")  # (n_colloids, n_actions)
 
-        # Compute the action
-        indices = self.sampling_strategy(logits)
-        # Add a small value to the log_probs to avoid log(0) errors.
-        eps = 1e-8
-        log_probs = np.log(jax.nn.softmax(logits) + eps)
+        if self._sample_mode == "discrete":
+            # Compute discrete action indices.
+            sampling_key = self._next_rng_key()
+            indices = self.sampling_strategy(logits, rng_key=sampling_key)
+            # Add a small value to the log_probs to avoid log(0) errors.
+            eps = 1e-8
+            log_probs = np.log(jax.nn.softmax(logits) + eps)
 
-        indices = self.exploration_policy(
-            indices, logits.shape[-1], onp.random.randint(8759865)
-        )
-        return (
-            indices,
-            np.take_along_axis(log_probs, indices.reshape(-1, 1), axis=1).reshape(-1),
-        )
+            if not self.deployment_mode:
+                exploration_key = self._next_rng_key()
+                exploration_seed = int(
+                    jax.random.randint(exploration_key, (), 0, 2**31 - 1)
+                )
+                indices = self.exploration_policy(
+                    indices, logits.shape[-1], exploration_seed
+                )
+            chosen_log_probs = np.take_along_axis(
+                log_probs, indices.reshape(-1, 1), axis=1
+            ).reshape(-1)
+
+            return (indices, chosen_log_probs)
+
+        elif self._sample_mode == "continuous":
+            # Continuous path: sampling strategy outputs action values directly.
+            sampling_key = self._next_rng_key()
+            exploration_key = self._next_rng_key()
+            calculate_log_probs = not self.deployment_mode
+            sampled_actions, log_probs = self.sampling_strategy(
+                logits=logits,
+                subkey=sampling_key,
+                calculate_log_probs=calculate_log_probs,
+                deployment_mode=self.deployment_mode,
+            )
+
+            actions = sampled_actions
+            if not self.deployment_mode:
+                actions = self.exploration_policy(
+                    model_actions=sampled_actions, rng_key=exploration_key
+                )
+            return actions, log_probs
+        else:
+            raise ValueError(f"Unsupported sampling mode: {self._sample_mode}")
 
     def export_model(self, filename: str = "model", directory: str = "Models"):
         """

--- a/swarmrl/sampling_strategies/__init__.py
+++ b/swarmrl/sampling_strategies/__init__.py
@@ -3,6 +3,21 @@ Module for sampling strategies.
 """
 
 from swarmrl.sampling_strategies.categorical_distribution import CategoricalDistribution
+from swarmrl.sampling_strategies.gaussian_distribution import (
+    ContinuousGaussianDistribution,
+)
 from swarmrl.sampling_strategies.gumbel_distribution import GumbelDistribution
+from swarmrl.sampling_strategies.sampling_strategy import (
+    ContinuousSamplingStrategy,
+    DiscreteSamplingStrategy,
+    SamplingStrategy,
+)
 
-__all__ = [CategoricalDistribution.__name__, GumbelDistribution.__name__]
+__all__ = [
+    SamplingStrategy.__name__,
+    DiscreteSamplingStrategy.__name__,
+    ContinuousSamplingStrategy.__name__,
+    CategoricalDistribution.__name__,
+    GumbelDistribution.__name__,
+    ContinuousGaussianDistribution.__name__,
+]

--- a/swarmrl/sampling_strategies/categorical_distribution.py
+++ b/swarmrl/sampling_strategies/categorical_distribution.py
@@ -8,12 +8,12 @@ import jax
 import jax.numpy as np
 import numpy as onp
 
-from swarmrl.sampling_strategies.sampling_strategy import SamplingStrategy
+from swarmrl.sampling_strategies.sampling_strategy import DiscreteSamplingStrategy
 
 
-class CategoricalDistribution(SamplingStrategy, ABC):
+class CategoricalDistribution(DiscreteSamplingStrategy, ABC):
     """
-    Class for the Gumbel distribution.
+    Class for the categorical distribution.
     """
 
     def __init__(self, noise: str = "none"):
@@ -39,7 +39,7 @@ class CategoricalDistribution(SamplingStrategy, ABC):
             )
             raise KeyError(msg)
 
-    def __call__(self, logits: np.ndarray) -> np.ndarray:
+    def __call__(self, logits: np.ndarray, rng_key=None) -> np.ndarray:
         """
         Sample from the distribution.
 
@@ -47,15 +47,19 @@ class CategoricalDistribution(SamplingStrategy, ABC):
         ----------
         logits : np.ndarray (n_colloids, n_dimensions)
                 Logits from the model to use in the computation for all colloids.
-        entropy : bool
-                If true, the Shannon entropy of the distribution is returned.
+        rng_key : Optional[jax.Array]
+                PRNG key for sampling. If ``None``, a random fallback key is created.
 
         Returns
         -------
         indices : np.ndarray (n_colloids,)
                 Index of the selected option in the distribution.
         """
-        rng = jax.random.PRNGKey(onp.random.randint(0, 1236534623))
+        rng = (
+            jax.random.PRNGKey(onp.random.randint(0, 1236534623))
+            if rng_key is None
+            else rng_key
+        )
 
         try:
             noise = self.noise(rng, shape=logits.shape)

--- a/swarmrl/sampling_strategies/gaussian_distribution.py
+++ b/swarmrl/sampling_strategies/gaussian_distribution.py
@@ -24,7 +24,10 @@ class ContinuousGaussianDistribution(ContinuousSamplingStrategy):
     """
 
     def __init__(
-        self, action_dimension: int, action_limits: Optional[jnp.ndarray] = None
+        self,
+        action_dimension: int,
+        action_limits: Optional[jnp.ndarray] = None,
+        float_precision: jnp.dtype = jnp.float32,
     ):
         self.action_dimension = int(action_dimension)
         if action_limits is not None:
@@ -36,8 +39,9 @@ class ContinuousGaussianDistribution(ContinuousSamplingStrategy):
         self.action_limits = (
             None
             if action_limits is None
-            else jnp.asarray(action_limits, dtype=jnp.float32)
+            else jnp.asarray(action_limits, dtype=float_precision)
         )
+        self.float_precision = float_precision
 
     def squash_action(self, action: jnp.ndarray) -> jnp.ndarray:
         """Squash actions to configured limits via tanh-affine transform."""
@@ -77,7 +81,7 @@ class ContinuousGaussianDistribution(ContinuousSamplingStrategy):
             ``(actions, log_probs)`` where ``log_probs`` is ``None`` when
             ``calculate_log_probs`` is false or ``deployment_mode`` is true.
         """
-        logits = jnp.asarray(logits, dtype=jnp.float32)
+        logits = jnp.asarray(logits, dtype=self.float_precision)
         if logits.shape[1] != 2 * self.action_dimension:
             raise ValueError(
                 "Logits must have shape (batch_size, 2 * action_dimension). "
@@ -93,9 +97,17 @@ class ContinuousGaussianDistribution(ContinuousSamplingStrategy):
                 subkey = rng_key
             if subkey is None:
                 subkey = jax.random.PRNGKey(onp.random.randint(0, 1236534623))
-            log_std = jnp.clip(logits[:, self.action_dimension :], -20.0, 1.0)
+            log_std = jnp.clip(
+                logits[:, self.action_dimension :],
+                self.float_precision(-20.0),
+                self.float_precision(1.0),
+            )
             std = jnp.exp(log_std)
-            pre_squash_action = jax.random.normal(subkey, shape=mean.shape) * std + mean
+            pre_squash_action = (
+                jax.random.normal(subkey, shape=mean.shape, dtype=self.float_precision)
+                * std
+                + mean
+            )
 
             if calculate_log_probs:
                 log_probs = -0.5 * (

--- a/swarmrl/sampling_strategies/gaussian_distribution.py
+++ b/swarmrl/sampling_strategies/gaussian_distribution.py
@@ -1,0 +1,123 @@
+"""Continuous Gaussian sampling strategy."""
+
+import logging
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+import numpy as onp
+
+from swarmrl.sampling_strategies.sampling_strategy import ContinuousSamplingStrategy
+
+logger = logging.getLogger(__name__)
+
+
+class ContinuousGaussianDistribution(ContinuousSamplingStrategy):
+    """
+    Sample continuous actions from a Gaussian policy parameterization.
+
+    Expected logits shape is ``(batch_size, 2 * action_dimension)`` where the
+    first half encodes mean and the second half encodes log-std. Sampled actions
+    are optionally tanh-squashed to ``action_limits``, if provided. In deployment mode, actions
+    are deterministic (mean action) and no log-probabilities are produced.
+    """
+
+    def __init__(
+        self, action_dimension: int, action_limits: Optional[jnp.ndarray] = None
+    ):
+        self.action_dimension = int(action_dimension)
+        if action_limits is not None:
+            if action_limits.shape != (action_dimension, 2):
+                raise ValueError(f"action_limits shape is {action_limits.shape} but should be {(action_dimension, 2)}")
+        self.action_limits = (
+            None
+            if action_limits is None
+            else jnp.asarray(action_limits, dtype=jnp.float32)
+        )
+
+    def squash_action(self, action: jnp.ndarray) -> jnp.ndarray:
+        """Squash actions to configured limits via tanh-affine transform."""
+        low = self.action_limits[:, 0]
+        high = self.action_limits[:, 1]
+        scale = (high - low) / 2.0
+        mid = (high + low) / 2.0
+        return jnp.tanh(action) * scale + mid
+
+    def __call__(
+        self,
+        logits: jnp.ndarray,
+        subkey: Optional[jax.Array] = None,
+        rng_key: Optional[jax.Array] = None,
+        calculate_log_probs: bool = True,
+        deployment_mode: bool = False,
+    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        """Return sampled continuous actions and optional per-sample log-probs.
+
+        Parameters
+        ----------
+        logits : jnp.ndarray
+            Tensor with shape ``(batch_size, 2 * action_dimension)``.
+        subkey : Optional[jax.Array]
+            PRNG subkey for sampling. Preferred key argument.
+        rng_key : Optional[jax.Array]
+            Alias for ``subkey`` for caller compatibility. Used only when
+            ``subkey`` is ``None``.
+        calculate_log_probs : bool
+            If true, compute tanh-corrected Gaussian log-probabilities.
+        deployment_mode : bool
+            If true, use deterministic actions (mean) and do not sample.
+
+        Returns
+        -------
+        tuple[jnp.ndarray, Optional[jnp.ndarray]]
+            ``(actions, log_probs)`` where ``log_probs`` is ``None`` when
+            ``calculate_log_probs`` is false or ``deployment_mode`` is true.
+        """
+        logits = jnp.asarray(logits, dtype=jnp.float32)
+        if logits.shape[1] != 2 * self.action_dimension:
+            raise ValueError(
+                "Logits must have shape (batch_size, 2 * action_dimension). "
+                f"Got {logits.shape} for action_dimension={self.action_dimension}."
+            )
+
+        mean = logits[:, : self.action_dimension]
+        if deployment_mode:
+            pre_squash_action = mean
+            log_probs = None
+        else:
+            if subkey is None:
+                subkey = rng_key
+            if subkey is None:
+                subkey = jax.random.PRNGKey(onp.random.randint(0, 1236534623))
+            log_std = jnp.clip(logits[:, self.action_dimension :], -20.0, 1.0)
+            std = jnp.exp(log_std)
+            pre_squash_action = jax.random.normal(subkey, shape=mean.shape) * std + mean
+
+            if calculate_log_probs:
+                log_probs = -0.5 * (
+                    ((pre_squash_action - mean) / std) ** 2
+                    + 2.0 * jnp.log(std)
+                    + jnp.log(2.0 * jnp.pi)
+                )
+                log_probs = log_probs.sum(axis=-1)
+
+                correction = (
+                    2.0
+                    * (
+                        jnp.log(2.0)
+                        - pre_squash_action
+                        - jax.nn.softplus(-2.0 * pre_squash_action)
+                    )
+                ).sum(axis=-1)
+                log_probs = log_probs - correction
+            else:
+                log_probs = None
+
+        actions = (
+            self.squash_action(pre_squash_action)
+            if self.action_limits is not None
+            else pre_squash_action
+        )
+        logger.debug(f"{actions=}, {log_probs=}, shape={actions.shape}")
+
+        return actions, log_probs

--- a/swarmrl/sampling_strategies/gaussian_distribution.py
+++ b/swarmrl/sampling_strategies/gaussian_distribution.py
@@ -18,8 +18,9 @@ class ContinuousGaussianDistribution(ContinuousSamplingStrategy):
 
     Expected logits shape is ``(batch_size, 2 * action_dimension)`` where the
     first half encodes mean and the second half encodes log-std. Sampled actions
-    are optionally tanh-squashed to ``action_limits``, if provided. In deployment mode, actions
-    are deterministic (mean action) and no log-probabilities are produced.
+    are optionally tanh-squashed to ``action_limits``, if provided.
+    In deployment mode, actions are deterministic (mean action) and
+    no log-probabilities are produced.
     """
 
     def __init__(
@@ -28,7 +29,10 @@ class ContinuousGaussianDistribution(ContinuousSamplingStrategy):
         self.action_dimension = int(action_dimension)
         if action_limits is not None:
             if action_limits.shape != (action_dimension, 2):
-                raise ValueError(f"action_limits shape is {action_limits.shape} but should be {(action_dimension, 2)}")
+                raise ValueError(
+                    f"action_limits shape is {action_limits.shape}"
+                    f"but should be {(action_dimension, 2)}"
+                )
         self.action_limits = (
             None
             if action_limits is None

--- a/swarmrl/sampling_strategies/gumbel_distribution.py
+++ b/swarmrl/sampling_strategies/gumbel_distribution.py
@@ -8,15 +8,15 @@ import jax
 import jax.numpy as np
 import numpy as onp
 
-from swarmrl.sampling_strategies.sampling_strategy import SamplingStrategy
+from swarmrl.sampling_strategies.sampling_strategy import DiscreteSamplingStrategy
 
 
-class GumbelDistribution(SamplingStrategy, ABC):
+class GumbelDistribution(DiscreteSamplingStrategy, ABC):
     """
     Class for the Gumbel distribution.
     """
 
-    def __call__(self, logits: np.ndarray) -> np.ndarray:
+    def __call__(self, logits: np.ndarray, rng_key=None) -> np.ndarray:
         """
         Sample from the distribution.
 
@@ -24,17 +24,23 @@ class GumbelDistribution(SamplingStrategy, ABC):
         ----------
         logits : np.ndarray (n_colloids, n_dimensions)
                 Logits from the model to use in the computation for all colloids.
+        rng_key : Optional[jax.Array]
+                PRNG key for sampling. If ``None``, a random fallback key is created.
 
         Returns
         -------
         indices : np.ndarray (n_colloids,)
-                Indeices of chosen actions for all colloids.
+                Indices of chosen actions for all colloids.
 
         Notes
         -----
         See https://arxiv.org/abs/1611.01144 for more information.
         """
-        rng = jax.random.PRNGKey(onp.random.randint(0, 1236534623))
+        rng = (
+            jax.random.PRNGKey(onp.random.randint(0, 1236534623))
+            if rng_key is None
+            else rng_key
+        )
         noise = jax.random.uniform(rng, shape=logits.shape)
 
         indices = np.argmax(logits - np.log(-np.log(noise)), axis=-1)

--- a/swarmrl/sampling_strategies/sampling_strategy.py
+++ b/swarmrl/sampling_strategies/sampling_strategy.py
@@ -2,10 +2,13 @@
 Parent class for sampling strategies.
 """
 
+from abc import ABC, abstractmethod
+from typing import Any
+
 import jax.numpy as np
 
 
-class SamplingStrategy:
+class SamplingStrategy(ABC):
     """
     Parent class for sampling strategies.
     """
@@ -23,7 +26,8 @@ class SamplingStrategy:
         probabilities += eps
         return -np.sum(probabilities * np.log(probabilities))
 
-    def __call__(self, logits: np.ndarray) -> int:
+    @abstractmethod
+    def __call__(self, logits: np.ndarray) -> Any:
         """
         Sample from the distribution.
 
@@ -38,3 +42,11 @@ class SamplingStrategy:
                 Index of the selected option in the distribution.
         """
         raise NotImplementedError("Implemented in child classes.")
+
+
+class DiscreteSamplingStrategy(SamplingStrategy, ABC):
+    """Parent class for discrete sampling strategies."""
+
+
+class ContinuousSamplingStrategy(SamplingStrategy, ABC):
+    """Parent class for continuous sampling strategies."""


### PR DESCRIPTION
#### Summary of additions and changes

* Refactored exploration policy hierarchy:
  * Added abstract `DiscreteExplorationPolicy` and `ContinuousExplorationPolicy` under `ExplorationPolicy`.
  * Updated `RandomExploration` to inherit from `DiscreteExplorationPolicy`.
  * Added and exported `GlobalOUExploration` as a continuous exploration policy using an Ornstein-Uhlenbeck process
* Refactored sampling strategy hierarchy:
  * Added abstract `DiscreteSamplingStrategy` and `ContinuousSamplingStrategy` under `SamplingStrategy`.
  * Updated `GumbelDistribution` and `CategoricalDistribution` to inherit from `DiscreteSamplingStrategy`.
  * Added `ContinuousGaussianDistribution` and exported it.
* Updated `FlaxModel` action path to support both discrete and continuous stacks:
  * Added mode inference and compatibility checks (`discrete` vs `continuous`).
  * Preserved existing discrete behavior.
  * Added continuous action branch (`sampling -> exploration`) with deployment-aware behavior.
  * Improved RNG handling with internal JAX key threading and subkey splitting.
* Added/updated tests:
  * New OU exploration tests.
  * New Gaussian sampling tests.
  * Updated Flax network tests for continuous mode + mode mismatch.
  * Updated sampling strategy base test to handle abstract base class.

#### How to test this pull request
Run the CI
##### Targeted tests for this PR scope
- `unit_tests/exploration_policies/test_ornstein_uhlenbeck_exploration.py`
- `unit_tests/sampling_strategies/test_gaussian.py`
- `unit_tests/sampling_strategies/test_sampling_strategy.py`
- `unit_tests/networks/test_flax_network.py`

#### Acknowledgment

This PR builds on the foundation established by @Mag-r. The architecture and implementation follow the direction set in that earlier work.
Many thanks for the contributions.


