### PR TITLE
Fix SpeciesSearch single-target different-type reward bug (Issue #93)

### DIFF
--- a/.github/workflows/espresso.yml
+++ b/.github/workflows/espresso.yml
@@ -49,6 +49,10 @@ jobs:
 
       - name: Run test suite
         run: |
+          # Ensure MODULEPATH contains the ESPResSo zen2 modules before restore.
+          # This mirrors the `module use` used in the Install step so
+          # `module restore espresso` can find the saved module.
+          test "${RUNNER_ARCH}" = "X64" && module use /cvmfs/dev.eessi.io/espresso/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all
           module restore espresso
           export NUM_PROC=$(nproc)
           export OMP_PROC_BIND=false 

--- a/CI/unit_tests/tasks/test_species_search.py
+++ b/CI/unit_tests/tasks/test_species_search.py
@@ -126,3 +126,41 @@ class TestSpeciesSearch:
         for _ in range(5):
             reward = self.task(colloids=colloids)
             assert reward[0] == 0.0
+
+    def test_single_target_other_type_regression(self):
+        """
+        Regression test for Issue #93:
+        sensing a different species with exactly one target must not zero-out rewards.
+        """
+
+        def decay_fn(x: float):
+            return -1 * x
+
+        task = SpeciesSearch(
+            decay_fn=decay_fn,
+            box_length=np.array([1.0, 1.0, 1.0]),
+            sensing_type=1,
+            avoid=False,
+            scale_factor=1.0,
+            particle_type=0,
+        )
+
+        # One target colloid of type 1 and two agents of type 0.
+        init_colloids = [
+            Colloid(np.array([0.0, 0.0, 0.0]), np.array([0.0, 1.0, 0]), 0, type=0),
+            Colloid(np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0]), 1, type=0),
+            Colloid(np.array([0.0, 1.0, 0.0]), np.array([0.0, 1.0, 0]), 2, type=1),
+        ]
+        task.initialize(colloids=init_colloids)
+
+        # Move one type-0 particle closer to the single type-1 target.
+        moved_colloids = [
+            Colloid(np.array([0.0, 0.5, 0.0]), np.array([0.0, 1.0, 0]), 0, type=0),
+            Colloid(np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0]), 1, type=0),
+            Colloid(np.array([0.0, 1.0, 0.0]), np.array([0.0, 1.0, 0]), 2, type=1),
+        ]
+
+        reward = task(colloids=moved_colloids)
+
+        # Particle 0 got closer by 0.5 -> decay(x)=-x gives positive delta reward 0.5.
+        assert reward[0] == pytest.approx(0.5)

--- a/swarmrl/tasks/searching/species_search.py
+++ b/swarmrl/tasks/searching/species_search.py
@@ -123,9 +123,15 @@ class SpeciesSearch(Task):
         distances = np.linalg.norm(
             (test_positions - reference_position) / self.box_length, axis=-1
         )
-        indices = np.asarray(np.nonzero(distances, size=distances.shape[0] - 1))
-        distances = np.take(distances, indices, axis=0)
-        field_value = self.decay_fn(distances).sum()
+
+        # Only remove the self-distance term when sensing the same particle type.
+        if self.sensing_type == self.particle_type:
+            include_mask = distances > 0
+        else:
+            include_mask = np.ones_like(distances, dtype=bool)
+
+        field_terms = self.decay_fn(distances) * include_mask.astype(distances.dtype)
+        field_value = field_terms.sum()
 
         return index, field_value - historic_value, field_value
 


### PR DESCRIPTION
Fix #93 
current logic wrongly removes one element unconditionally, leaving empty distances

#### Summary of additions and changes
* Added a test for the described bug.
* Updated `species_search.py` in `compute_single_particle_task`. Removed the fragile nonzero(..., size=n-1) indexing logic and added mask-based handling

#### How to test this pull request
Run CI