### PR TITLE
refactor: clarify random exploration masking

### DIFF
--- a/swarmrl/exploration_policies/random_exploration.py
+++ b/swarmrl/exploration_policies/random_exploration.py
@@ -49,24 +49,21 @@ class RandomExploration(DiscreteExplorationPolicy):
                 each colloid.
         """
         key = jax.random.PRNGKey(seed)
-        sample = jax.random.uniform(key, shape=model_actions.shape)
+        sample_key, action_key = jax.random.split(key)
 
-        to_be_changed = np.clip(sample - self.probability, min=0, max=1)
-        to_be_changed = np.clip(to_be_changed * 1e6, min=0, max=1)
-        not_to_be_changed = np.clip(to_be_changed * -10 + 1, 0, 1)
+        replace_mask = (
+            jax.random.uniform(sample_key, shape=model_actions.shape) < self.probability
+        )
 
-        # Choose random actions
-        key, subkey = jax.random.split(key)
         exploration_actions = jax.random.randint(
-            subkey,
+            action_key,
             shape=(model_actions.shape[0],),
             minval=0,
             maxval=action_space_length,
         )
 
-        # Put the new actions in.
-        model_actions = (
-            model_actions * to_be_changed + exploration_actions * not_to_be_changed
+        return np.where(
+            replace_mask,
+            exploration_actions,
+            model_actions,
         ).astype(np.int16)
-
-        return model_actions


### PR DESCRIPTION
Replace the arithmetic masks with an explicit Boolean mask and `np.where`. 
The old names contradicted their behavior: `to_be_changed` actually marked actions to keep. The new logic directly expresses the intended replacement probability.
