### PR TITLE
fix: pass JAX PRNG keys directly to exploration policies

### DIFF
--- a/CI/unit_tests/action_selection/test_action_selector.py
+++ b/CI/unit_tests/action_selection/test_action_selector.py
@@ -27,8 +27,11 @@ class _DummyDiscreteSampling(DiscreteSamplingStrategy):
 class _DummyDiscreteExploration(DiscreteExplorationPolicy):
     """Discrete exploration that shifts indices by +1 modulo action space."""
 
-    def __call__(self, model_action, action_space_length, seed=12345):
-        del seed
+    def __init__(self):
+        self.rng_key = None
+
+    def __call__(self, model_action, action_space_length, rng_key):
+        self.rng_key = rng_key
         return (model_action + 1) % action_space_length
 
 
@@ -91,6 +94,25 @@ class TestActionSelector:
 
         onp.testing.assert_array_equal(indices, expected_indices)
         onp.testing.assert_allclose(chosen_log_probs, expected_log_probs)
+
+    def test_discrete_training_forwards_exploration_key(self):
+        exploration_policy = _DummyDiscreteExploration()
+        selector = ActionSelector(
+            sampling_strategy=_DummyDiscreteSampling(),
+            exploration_policy=exploration_policy,
+        )
+
+        logits = np.array([[1.0, 3.0, 2.0], [4.0, 1.0, 0.0]], dtype=np.float32)
+        exploration_key = jax.random.PRNGKey(1)
+
+        selector.select(
+            logits=logits,
+            deployment_mode=False,
+            sampling_key=jax.random.PRNGKey(0),
+            exploration_key=exploration_key,
+        )
+
+        onp.testing.assert_array_equal(exploration_policy.rng_key, exploration_key)
 
     def test_discrete_deployment_skips_exploration(self):
         selector = ActionSelector(

--- a/CI/unit_tests/exploration_policies/test_random_exploration.py
+++ b/CI/unit_tests/exploration_policies/test_random_exploration.py
@@ -2,6 +2,7 @@
 Test the random exploration module.
 """
 
+import jax
 import jax.numpy as np
 from numpy.testing import assert_array_equal, assert_raises
 
@@ -29,7 +30,9 @@ class TestRandomExploration:
         # Force a new point
         self.explorer.probability = 1.0
         chosen_actions = self.explorer(
-            model_actions=self.chosen_actions, action_space_length=4, seed=0
+            model_actions=self.chosen_actions,
+            action_space_length=4,
+            rng_key=jax.random.PRNGKey(0),
         )
         assert_raises(
             AssertionError, assert_array_equal, chosen_actions, self.chosen_actions
@@ -43,6 +46,8 @@ class TestRandomExploration:
 
         for i in range(100):
             chosen_actions = explorer(
-                model_actions=self.chosen_actions, action_space_length=4, seed=i
+                model_actions=self.chosen_actions,
+                action_space_length=4,
+                rng_key=jax.random.PRNGKey(i),
             )
             assert_array_equal(chosen_actions, self.chosen_actions)

--- a/swarmrl/action_selection/action_selector.py
+++ b/swarmrl/action_selection/action_selector.py
@@ -64,11 +64,8 @@ class ActionSelector:
             log_probs = jax.nn.log_softmax(logits)
 
             if not deployment_mode:
-                exploration_seed = int(
-                    jax.random.randint(exploration_key, (), 0, 2**31 - 1)
-                )
                 indices = self.exploration_policy(
-                    indices, logits.shape[-1], exploration_seed
+                    indices, logits.shape[-1], exploration_key
                 )
             expanded_indices = np.expand_dims(indices, axis=-1)
             chosen_log_probs = np.take_along_axis(log_probs, expanded_indices, axis=-1)

--- a/swarmrl/exploration_policies/exploration_policy.py
+++ b/swarmrl/exploration_policies/exploration_policy.py
@@ -29,7 +29,10 @@ class DiscreteExplorationPolicy(ExplorationPolicy, ABC):
 
     @abstractmethod
     def __call__(
-        self, model_actions: np.ndarray, action_space_length: int, seed: Any
+        self,
+        model_actions: np.ndarray,
+        action_space_length: int,
+        rng_key: jax.Array,
     ) -> np.ndarray:
         """
         Return an index associated with the chosen action.
@@ -41,6 +44,8 @@ class DiscreteExplorationPolicy(ExplorationPolicy, ABC):
         action_space_length : int
                 Number of possible actions. Should be 1 higher than the actual highest
                 index, i.e if I have actions [0, 1, 2, 3] this number should be 4.
+        rng_key : jax.Array
+                Key for JAX random number generation.
 
         Returns
         -------
@@ -57,9 +62,7 @@ class ContinuousExplorationPolicy(ExplorationPolicy, ABC):
     """
 
     @abstractmethod
-    def __call__(
-        self, model_actions: np.ndarray, rng_key: jax.random.PRNGKey
-    ) -> np.ndarray:
+    def __call__(self, model_actions: np.ndarray, rng_key: jax.Array) -> np.ndarray:
         """
         Return an action value
 
@@ -67,8 +70,8 @@ class ContinuousExplorationPolicy(ExplorationPolicy, ABC):
         ----------
         model_actions : np.ndarray (n_colloids,)
                 Action chosen by the model for each colloid.
-        rng_key : jax.random.PRNGKey
-                Key for jax.random module
+        rng_key : jax.Array
+                Key for JAX random number generation.
 
         Returns
         -------

--- a/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
+++ b/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
@@ -100,9 +100,7 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         self.noise = self.noise * decay
         self.epsilon = np.maximum(self.epsilon * decay, self.float_precision(0.01))
 
-    def __call__(
-        self, model_actions: np.ndarray, rng_key: jax.random.PRNGKey
-    ) -> np.ndarray:
+    def __call__(self, model_actions: np.ndarray, rng_key: jax.Array) -> np.ndarray:
         """
         Add OU noise to model actions.
 

--- a/swarmrl/exploration_policies/random_exploration.py
+++ b/swarmrl/exploration_policies/random_exploration.py
@@ -29,7 +29,7 @@ class RandomExploration(DiscreteExplorationPolicy):
 
     @partial(jax.jit, static_argnums=(0,))
     def __call__(
-        self, model_actions: np.ndarray, action_space_length: int, seed
+        self, model_actions: np.ndarray, action_space_length: int, rng_key: jax.Array
     ) -> np.ndarray:
         """
         Return an index associated with the chosen action.
@@ -41,6 +41,8 @@ class RandomExploration(DiscreteExplorationPolicy):
         action_space_length : int
                 Number of possible actions. Should be 1 higher than the actual highest
                 index, i.e if I have actions [0, 1, 2, 3] this number should be 4.
+        rng_key : jax.Array
+                Key for JAX random number generation.
 
         Returns
         -------
@@ -48,15 +50,14 @@ class RandomExploration(DiscreteExplorationPolicy):
                 Action chosen after the exploration module has operated for
                 each colloid.
         """
-        key = jax.random.PRNGKey(seed)
-        sample = jax.random.uniform(key, shape=model_actions.shape)
+        sample = jax.random.uniform(rng_key, shape=model_actions.shape)
 
         to_be_changed = np.clip(sample - self.probability, min=0, max=1)
         to_be_changed = np.clip(to_be_changed * 1e6, min=0, max=1)
         not_to_be_changed = np.clip(to_be_changed * -10 + 1, 0, 1)
 
         # Choose random actions
-        key, subkey = jax.random.split(key)
+        _, subkey = jax.random.split(rng_key)
         exploration_actions = jax.random.randint(
             subkey,
             shape=(model_actions.shape[0],),


### PR DESCRIPTION
Pass JAX PRNG keys directly to exploration policies and update interfaces and tests accordingly.
Avoid converting JAX values to Python integers and keep random-key handling consistent with JAX conventions.