### PR TITLE
Handle trajectory termination and truncation boundaries

### DIFF
--- a/CI/integration_tests/intrinsic_reward/_test_rnd_intrinsic_reward_deployment.py
+++ b/CI/integration_tests/intrinsic_reward/_test_rnd_intrinsic_reward_deployment.py
@@ -1,7 +1,7 @@
 import unittest as ut
 from dataclasses import dataclass
 
-import jax.numpy as np
+import jax.numpy as jnp
 from flax import linen as nn
 from jax import random
 
@@ -22,7 +22,7 @@ class RNDNet(nn.Module):
 
 @dataclass
 class EpisodeDataDummy:
-    features: np.ndarray
+    features: jnp.ndarray
 
 
 class RNDTest(ut.TestCase):

--- a/CI/unit_tests/action_selection/test_action_selector.py
+++ b/CI/unit_tests/action_selection/test_action_selector.py
@@ -1,7 +1,7 @@
 """Unit tests for ActionSelector orchestration."""
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 import pytest
 
@@ -21,7 +21,7 @@ class _DummyDiscreteSampling(DiscreteSamplingStrategy):
 
     def __call__(self, logits, rng_key=None):
         del rng_key
-        return np.argmax(logits, axis=-1)
+        return jnp.argmax(logits, axis=-1)
 
 
 class _DummyDiscreteExploration(DiscreteExplorationPolicy):
@@ -45,7 +45,7 @@ class _DummyContinuousSampling(ContinuousSamplingStrategy):
         del subkey, deployment_mode
         actions = logits[:, :2]
         if calculate_log_probs:
-            return actions, np.zeros((logits.shape[0],), dtype=logits.dtype)
+            return actions, jnp.zeros((logits.shape[0],), dtype=logits.dtype)
         return actions, None
 
 
@@ -73,7 +73,7 @@ class TestActionSelector:
             exploration_policy=_DummyDiscreteExploration(),
         )
 
-        logits = np.array([[1.0, 3.0, 2.0], [4.0, 1.0, 0.0]], dtype=np.float32)
+        logits = jnp.array([[1.0, 3.0, 2.0], [4.0, 1.0, 0.0]], dtype=jnp.float32)
         sampling_key = jax.random.PRNGKey(0)
         exploration_key = jax.random.PRNGKey(1)
 
@@ -84,8 +84,8 @@ class TestActionSelector:
             exploration_key=exploration_key,
         )
 
-        expected_indices = np.array([2, 1])
-        expected_log_probs = np.take_along_axis(
+        expected_indices = jnp.array([2, 1])
+        expected_log_probs = jnp.take_along_axis(
             jax.nn.log_softmax(logits), expected_indices.reshape(-1, 1), axis=-1
         ).reshape(-1)
 
@@ -98,7 +98,7 @@ class TestActionSelector:
             exploration_policy=_DummyDiscreteExploration(),
         )
 
-        logits = np.array([[1.0, 3.0, 2.0], [4.0, 1.0, 0.0]], dtype=np.float32)
+        logits = jnp.array([[1.0, 3.0, 2.0], [4.0, 1.0, 0.0]], dtype=jnp.float32)
         sampling_key = jax.random.PRNGKey(2)
         exploration_key = jax.random.PRNGKey(3)
 
@@ -109,8 +109,8 @@ class TestActionSelector:
             exploration_key=exploration_key,
         )
 
-        expected_indices = np.array([1, 0])
-        expected_log_probs = np.take_along_axis(
+        expected_indices = jnp.array([1, 0])
+        expected_log_probs = jnp.take_along_axis(
             jax.nn.log_softmax(logits), expected_indices.reshape(-1, 1), axis=-1
         ).reshape(-1)
 
@@ -123,8 +123,8 @@ class TestActionSelector:
             exploration_policy=_DummyContinuousExploration(),
         )
 
-        logits = np.array(
-            [[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32
+        logits = jnp.array(
+            [[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=jnp.float32
         )
         sampling_key = jax.random.PRNGKey(4)
         exploration_key = jax.random.PRNGKey(5)
@@ -137,7 +137,7 @@ class TestActionSelector:
         )
 
         expected_actions = logits[:, :2] + 1.0
-        expected_log_probs = np.zeros((2,), dtype=np.float32)
+        expected_log_probs = jnp.zeros((2,), dtype=jnp.float32)
 
         onp.testing.assert_allclose(actions, expected_actions)
         onp.testing.assert_allclose(log_probs, expected_log_probs)
@@ -148,8 +148,8 @@ class TestActionSelector:
             exploration_policy=_DummyContinuousExploration(),
         )
 
-        logits = np.array(
-            [[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=np.float32
+        logits = jnp.array(
+            [[0.1, 0.2, 0.3, 0.4], [0.5, -0.1, 0.6, -0.2]], dtype=jnp.float32
         )
         sampling_key = jax.random.PRNGKey(6)
         exploration_key = jax.random.PRNGKey(7)

--- a/CI/unit_tests/agents/test_actor_critic_trajectory_boundaries.py
+++ b/CI/unit_tests/agents/test_actor_critic_trajectory_boundaries.py
@@ -1,0 +1,132 @@
+import numpy as np
+
+from swarmrl.actions import Action
+from swarmrl.agents.actor_critic import ActorCriticAgent
+from swarmrl.components import Colloid
+from swarmrl.force_functions import ForceFunction
+from swarmrl.tasks import Task
+from swarmrl.utils import TrajectoryInformation
+
+
+class _Network:
+    def compute_action(self, observables):
+        n_particles = len(observables)
+        return np.zeros(n_particles, dtype=int), np.zeros(n_particles)
+
+
+class _StatefulObservable:
+    def __init__(self):
+        self.calls = 0
+
+    def initialize(self, colloids):
+        self.calls = 0
+
+    def compute_observable(self, colloids):
+        self.calls += 1
+        return np.array([[colloid.pos[0]] for colloid in colloids])
+
+
+class _Task(Task):
+    def __init__(self, terminate=False):
+        super().__init__(particle_type=0)
+        self.terminate = terminate
+
+    def __call__(self, colloids):
+        self.kill_switch = self.terminate
+        return np.ones(len(colloids))
+
+
+def _colloids(x):
+    return [
+        Colloid(
+            pos=np.array([x, 0.0, 0.0]),
+            director=np.array([1.0, 0.0, 0.0]),
+            id=0,
+            velocity=np.zeros(3),
+            type=0,
+        )
+    ]
+
+
+def _agent(terminate=False):
+    return ActorCriticAgent(
+        particle_type=0,
+        network=_Network(),
+        task=_Task(terminate=terminate),
+        observable=_StatefulObservable(),
+        actions={"idle": Action()},
+    )
+
+
+def test_trajectory_information_has_transition_boundary_fields():
+    trajectory = TrajectoryInformation(particle_type=0)
+
+    assert trajectory.terminated == []
+    assert trajectory.truncated == []
+    assert trajectory.final_observation is None
+
+
+def test_reward_records_resulting_observation_and_aligned_status():
+    agent = _agent(terminate=False)
+    agent.reset_agent(_colloids(0.0))
+
+    agent.calc_action(_colloids(0.0))
+    agent.calc_reward(_colloids(1.0))
+
+    assert agent.trajectory.terminated == [False]
+    assert agent.trajectory.truncated == [False]
+    np.testing.assert_array_equal(agent.trajectory.final_observation, [[1.0]])
+    assert agent.observable.calls == 2
+
+
+def test_final_observation_is_reused_for_next_rollout_action():
+    agent = _agent(terminate=False)
+    agent.reset_agent(_colloids(0.0))
+    agent.calc_action(_colloids(0.0))
+    agent.calc_reward(_colloids(1.0))
+    final_observation = agent.trajectory.final_observation
+
+    agent.reset_trajectory(preserve_pending_observation=True)
+    agent.calc_action(_colloids(1.0))
+
+    assert agent.observable.calls == 2
+    np.testing.assert_array_equal(agent.trajectory.features[0], final_observation)
+
+
+def test_rollout_end_prioritizes_termination_over_truncation():
+    agent = _agent(terminate=False)
+    agent.reset_agent(_colloids(0.0))
+    agent.calc_action(_colloids(0.0))
+    agent.calc_reward(_colloids(1.0))
+    agent.update_agent = lambda: [2.0]
+
+    agent.on_rollout_end(terminated=True, truncated=True)
+
+    assert agent.trajectory.terminated == [True]
+    assert agent.trajectory.truncated == [False]
+
+
+def test_task_termination_updates_force_function_immediately():
+    agent = _agent(terminate=True)
+    agent.reset_agent(_colloids(0.0))
+    force_fn = ForceFunction(agents={"0": agent})
+    force_fn.calc_action(_colloids(0.0))
+
+    force_fn.calc_reward(_colloids(1.0))
+
+    assert force_fn.kill_switch is True
+    assert agent.trajectory.terminated == [True]
+
+
+def test_rollout_end_hook_owns_actor_critic_boundary_and_update():
+    agent = _agent(terminate=False)
+    agent.reset_agent(_colloids(0.0))
+    agent.calc_action(_colloids(0.0))
+    agent.calc_reward(_colloids(1.0))
+    agent.update_agent = lambda: [2.0]
+
+    result = agent.on_rollout_end(terminated=False, truncated=True)
+
+    assert agent.trajectory.terminated == [False]
+    assert agent.trajectory.truncated == [True]
+    assert result == [2.0]

--- a/CI/unit_tests/components/test_components.py
+++ b/CI/unit_tests/components/test_components.py
@@ -2,7 +2,7 @@
 Test the SwarmRL agents
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 from numpy.testing import assert_array_equal
 
 from swarmrl.components.colloid import Colloid
@@ -19,10 +19,10 @@ class TestComponents:
         Test the colloid agent.
         """
         colloid = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=0,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=0,
         )
 
@@ -37,10 +37,10 @@ class TestComponents:
         Test the pytree aspects of the colloid.
         """
         colloid = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=0,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=0,
         )
 
@@ -54,26 +54,26 @@ class TestComponents:
         Test the swarm agent.
         """
         colloid_1 = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=0,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=0,
         )
 
         colloid_2 = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=1,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=0,
         )
 
         colloid_3 = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=2,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=1,
         )
 
@@ -94,26 +94,26 @@ class TestComponents:
         Test the partial swarm extraction methods.
         """
         colloid_1 = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=0,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=0,
         )
 
         colloid_2 = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=1,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=0,
         )
 
         colloid_3 = Colloid(
-            pos=np.array([0.0, 0.0, 0.0]),
-            director=np.array([0.0, 0.0, 1.0]),
+            pos=jnp.array([0.0, 0.0, 0.0]),
+            director=jnp.array([0.0, 0.0, 1.0]),
             id=2,
-            velocity=np.array([0.0, 0.0, 0.0]),
+            velocity=jnp.array([0.0, 0.0, 0.0]),
             type=1,
         )
 

--- a/CI/unit_tests/engines/test_real_experiment.py
+++ b/CI/unit_tests/engines/test_real_experiment.py
@@ -14,6 +14,7 @@ import unittest as ut
 import numpy as np
 
 import swarmrl.engine.real_experiment
+from swarmrl.actions import Action
 from swarmrl.agents.dummy_models import ConstForce
 from swarmrl.force_functions import ForceFunction
 
@@ -42,6 +43,7 @@ class MockConnection:
 
         # the first message of the experiment will always be the data size
         self.next_message = MessageType.DATA_SIZE
+        self.send_calls = 0
 
     def recv(self, data_size: int) -> bytes:
         """
@@ -74,6 +76,7 @@ class MockConnection:
         """
         Receive data from the engine and check that the values are sensible
         """
+        self.send_calls += 1
         # experiment expects data to be F-Style flattened
         data_unpacked = np.array(struct.unpack(str(len(data) // 8) + "d", data))
         data_matrix = data_unpacked.reshape((-1, 2), order="F")
@@ -95,6 +98,32 @@ class TestRealExperiment(ut.TestCase):
         force_fn = ForceFunction({"0": agent})
         runner.integrate(10, force_fn)
         runner.finalize()
+
+    def test_termination_does_not_send_an_extra_action(self):
+        class TerminatingForceFunction:
+            kill_switch = False
+
+            def __init__(self):
+                self.action_calls = 0
+                self.reward_calls = 0
+
+            def calc_action(self, colloids):
+                self.action_calls += 1
+                return [Action() for _ in colloids]
+
+            def calc_reward(self, colloids):
+                self.reward_calls += 1
+                self.kill_switch = True
+
+        connection = MockConnection(n_partcl=2, box_l=1.0)
+        runner = swarmrl.engine.real_experiment.RealExperiment(connection)
+        force_fn = TerminatingForceFunction()
+
+        runner.integrate(10, force_fn)
+
+        assert force_fn.reward_calls == 1
+        assert force_fn.action_calls == 1
+        assert connection.send_calls == 1
 
 
 if __name__ == "__main__":

--- a/CI/unit_tests/exploration_policies/test_random_exploration.py
+++ b/CI/unit_tests/exploration_policies/test_random_exploration.py
@@ -2,7 +2,7 @@
 Test the random exploration module.
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 from numpy.testing import assert_array_equal, assert_raises
 
 from swarmrl.exploration_policies.random_exploration import RandomExploration
@@ -20,7 +20,7 @@ class TestRandomExploration:
         """
         cls.explorer = RandomExploration(probability=0.8)
 
-        cls.chosen_actions = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+        cls.chosen_actions = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
 
     def test_definite_action(self):
         """

--- a/CI/unit_tests/intrinsic_reward/_test_rnd_intrinsic_reward.py
+++ b/CI/unit_tests/intrinsic_reward/_test_rnd_intrinsic_reward.py
@@ -1,7 +1,7 @@
 import unittest as ut
 from dataclasses import dataclass
 
-import jax.numpy as np
+import jax.numpy as jnp
 from flax import linen as nn
 from jax import random
 
@@ -22,7 +22,7 @@ class RNDNet(nn.Module):
 
 @dataclass
 class EpisodeDataDummy:
-    features: np.ndarray
+    features: jnp.ndarray
 
 
 class RNDTest(ut.TestCase):

--- a/CI/unit_tests/losses/test_proximal_policy_loss.py
+++ b/CI/unit_tests/losses/test_proximal_policy_loss.py
@@ -1,5 +1,5 @@
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy.testing as tst
 import optax
 
@@ -10,20 +10,20 @@ from swarmrl.utils.utils import gather_n_dim_indices
 
 class DummyNetwork:
     def apply_fn(self, params, features):
-        out_shape = np.shape(features)
-        log_probs = 2.0 * np.ones((out_shape[0], out_shape[1], 4))
-        values = np.array([np.ones((out_shape[0], out_shape[1]))])
+        out_shape = jnp.shape(features)
+        log_probs = 2.0 * jnp.ones((out_shape[0], out_shape[1], 4))
+        values = jnp.ones((out_shape[0], out_shape[1], 1))
         return log_probs, values
 
     def __call__(self, params, features):
         return self.apply_fn(params, features)
 
 
-def dummy_value_function(rewards, values):
-    advantages = np.ones_like(rewards)
-    sign = np.sign(rewards)
+def dummy_value_function(rewards, values, terminated, truncated):
+    advantages = jnp.ones_like(rewards)
+    sign = jnp.sign(rewards)
 
-    returns = 2 * np.array([np.ones_like(rewards)])
+    returns = 2 * jnp.ones_like(rewards)
     return advantages * sign, returns
 
 
@@ -59,21 +59,24 @@ class TestProximalPolicyLoss:
         network = DummyNetwork()
         network_params = 10
 
-        features = np.ones((n_time_steps, n_particles, observable_dimension))
+        features = jnp.ones((n_time_steps, n_particles, observable_dimension))
+        final_observation = jnp.ones((n_particles, observable_dimension))
+        terminated = jnp.zeros(n_time_steps, dtype=bool)
+        truncated = jnp.zeros(n_time_steps, dtype=bool)
 
-        actions = np.ones((n_time_steps, n_particles), dtype=int)
+        actions = jnp.ones((n_time_steps, n_particles), dtype=int)
 
         # all log_probs are 2 such that the ratio is 1
-        old_log_probs_0 = 2 * np.ones((n_time_steps, n_particles))
+        old_log_probs_0 = 2 * jnp.ones((n_time_steps, n_particles))
         # all log_probs are 0 such that the ratio is e^2 > 1 + epsilon
-        old_log_probs_1 = 0 * np.ones((n_time_steps, n_particles))
+        old_log_probs_1 = 0 * jnp.ones((n_time_steps, n_particles))
         # all log_probs are 3 such that the ratio is e^-2 < 1 - epsilon
-        old_log_probs_2 = 3 * np.ones((n_time_steps, n_particles))
+        old_log_probs_2 = 3 * jnp.ones((n_time_steps, n_particles))
 
         # all advantages are 1
-        rewards = np.ones((n_time_steps, n_particles))
+        rewards = jnp.ones((n_time_steps, n_particles))
         # all advantages are -1
-        rewards2 = np.ones((n_time_steps, n_particles))
+        rewards2 = jnp.ones((n_time_steps, n_particles))
 
         old_log_probs_list = [old_log_probs_0, old_log_probs_1, old_log_probs_2]
         rewards_list = [rewards, rewards2]
@@ -91,37 +94,78 @@ class TestProximalPolicyLoss:
                         action_indices=actions,
                         old_log_probs=probs,
                         rewards=rewards,
+                        final_observation=final_observation,
+                        terminated=terminated,
+                        truncated=truncated,
                     )
                 )
 
         # now compute the loss by hand.
         def ratio(new_log_props, old_log_probs):
-            return np.exp(new_log_props - old_log_probs)
+            return jnp.exp(new_log_props - old_log_probs)
 
         new_logits, new_predicted_values = network.apply_fn(network_params, features)
+        new_predicted_values = new_predicted_values.squeeze(axis=-1)
         # the dummy_actor will return just 2
-        new_log_probs_all = np.log(jax.nn.softmax(new_logits, axis=-1) + 1e-8)
+        new_log_probs_all = jnp.log(jax.nn.softmax(new_logits, axis=-1) + 1e-8)
         new_log_probs = gather_n_dim_indices(new_log_probs_all, actions)
         # calculate the entropy of the new_log_probs
-        entropy = np.sum(sampling_strategy.compute_entropy(np.exp(new_log_probs_all)))
+        entropy = jnp.sum(sampling_strategy.compute_entropy(jnp.exp(new_log_probs_all)))
 
         # These results will be compared to the results of the PPO loss function
         true_results = []
         for probs in old_log_probs_list:
             for rewards in rewards_list:
                 ratios = ratio(new_log_probs, probs)
-                advantages, returns = value_function(rewards, None)
-                clipped_loss = -1 * np.minimum(
-                    ratios * advantages,
-                    np.clip(ratios, 1 - epsilon, 1 + epsilon) * advantages,
+                advantages, returns = value_function(
+                    rewards, None, terminated, truncated
                 )
-                loss = np.sum(clipped_loss, 0)
+                clipped_loss = -1 * jnp.minimum(
+                    ratios * advantages,
+                    jnp.clip(ratios, 1 - epsilon, 1 + epsilon) * advantages,
+                )
+                loss = jnp.sum(clipped_loss, 0)
 
                 critic_loss = optax.huber_loss(new_predicted_values, returns)
-                critic_loss = np.sum(critic_loss)
-                loss = np.sum(loss) - entropy_coefficient * entropy + 0.5 * critic_loss
+                critic_loss = jnp.sum(critic_loss)
+                loss = jnp.sum(loss) - entropy_coefficient * entropy + 0.5 * critic_loss
                 true_results.append(loss)
 
         # compare the results of the PPO loss function with the results computed by hand
         for i, ppo_loss in enumerate(results):
             tst.assert_almost_equal(ppo_loss, true_results[i], decimal=3)
+
+    def test_bootstrapped_return_is_a_detached_critic_target(self):
+        class ParameterizedNetwork:
+            def __call__(self, params, features):
+                shape = features.shape[:2]
+                logits = jnp.zeros((*shape, 2))
+                values = params * jnp.ones((*shape, 1))
+                return logits, values
+
+        def value_function(rewards, values, terminated, truncated):
+            advantages = jnp.zeros_like(rewards)
+            returns = 2.0 * values[1:]
+            return advantages, returns
+
+        loss = ProximalPolicyLoss(
+            value_function=value_function,
+            entropy_coefficient=0.0,
+            n_epochs=1,
+        )
+        features = jnp.ones((2, 1, 1))
+        final_observation = jnp.ones((1, 1))
+
+        gradient = jax.grad(loss._calculate_loss)(
+            jnp.array(1.0),
+            network=ParameterizedNetwork(),
+            feature_data=features,
+            action_indices=jnp.zeros((2, 1), dtype=int),
+            rewards=jnp.zeros((2, 1)),
+            old_log_probs=jnp.full((2, 1), -jnp.log(2.0)),
+            final_observation=final_observation,
+            terminated=jnp.zeros(2, dtype=bool),
+            truncated=jnp.zeros(2, dtype=bool),
+        )
+
+        assert gradient < 0.0

--- a/CI/unit_tests/sampling_strategies/test_categorical.py
+++ b/CI/unit_tests/sampling_strategies/test_categorical.py
@@ -2,7 +2,7 @@
 Test the categorical distribution.
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 from numpy.testing import assert_array_almost_equal
 
@@ -19,11 +19,11 @@ class TestCategorical:
         """
         Set some initial attributes.
         """
-        cls.even_logits = np.array([6.0, 6.0, 6.0, 6.0])
-        cls.even_probabilities = np.array([0.25, 0.25, 0.25, 0.25])
+        cls.even_logits = jnp.array([6.0, 6.0, 6.0, 6.0])
+        cls.even_probabilities = jnp.array([0.25, 0.25, 0.25, 0.25])
 
-        cls.definite_logits = np.array([10.0, 0.0])
-        cls.definite_probabilities = np.array([1.0, 0.0])
+        cls.definite_logits = jnp.array([10.0, 0.0])
+        cls.definite_probabilities = jnp.array([1.0, 0.0])
 
     def test_even_logits(self):
         """
@@ -69,8 +69,8 @@ class TestCategorical:
         """
         sampler = CategoricalDistribution()
 
-        logits = np.array([[3.0, 3.0, 3.0, 3.0], [100.0, 0.0, 0.0, 0.0]])
-        probabilities = np.array([[0.25, 0.25, 0.25, 0.25], [1.0, 0.0, 0.0, 0.0]])
+        logits = jnp.array([[3.0, 3.0, 3.0, 3.0], [100.0, 0.0, 0.0, 0.0]])
+        probabilities = jnp.array([[0.25, 0.25, 0.25, 0.25], [1.0, 0.0, 0.0, 0.0]])
 
         # Collect points for different cases.
         single_outcomes_0 = onp.array([0.0, 0.0, 0.0, 0.0])

--- a/CI/unit_tests/sampling_strategies/test_gumbel.py
+++ b/CI/unit_tests/sampling_strategies/test_gumbel.py
@@ -2,7 +2,7 @@
 Test the Gumbel distribution.
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 from numpy.testing import assert_array_almost_equal
 
@@ -20,11 +20,11 @@ class TestCategorical:
         Set some initial attributes.
         """
         cls.sampler = GumbelDistribution()
-        cls.even_logits = np.array([6.0, 6.0, 6.0, 6.0])
-        cls.even_probabilities = np.array([0.25, 0.25, 0.25, 0.25])
+        cls.even_logits = jnp.array([6.0, 6.0, 6.0, 6.0])
+        cls.even_probabilities = jnp.array([0.25, 0.25, 0.25, 0.25])
 
-        cls.definite_logits = np.array([10.0, 0.0])
-        cls.definite_probabilities = np.array([1.0, 0.0])
+        cls.definite_logits = jnp.array([10.0, 0.0])
+        cls.definite_probabilities = jnp.array([1.0, 0.0])
 
     def test_even_logits(self):
         """
@@ -40,8 +40,8 @@ class TestCategorical:
         """
         Ensure the sampler works for many colloids.
         """
-        logits = np.array([[3.0, 3.0, 3.0, 3.0], [100.0, 0.0, 0.0, 0.0]])
-        probabilities = np.array([[0.25, 0.25, 0.25, 0.25], [1.0, 0.0, 0.0, 0.0]])
+        logits = jnp.array([[3.0, 3.0, 3.0, 3.0], [100.0, 0.0, 0.0, 0.0]])
+        probabilities = jnp.array([[0.25, 0.25, 0.25, 0.25], [1.0, 0.0, 0.0, 0.0]])
 
         # Collect points for different cases.
         single_outcomes_0 = onp.array([0.0, 0.0, 0.0, 0.0])

--- a/CI/unit_tests/trainers/test_trainer_storage_hooks.py
+++ b/CI/unit_tests/trainers/test_trainer_storage_hooks.py
@@ -1,6 +1,7 @@
-"""Tests for trainer-level storage lifecycle hooks."""
+"""Tests for trainer-level agent lifecycle hooks."""
 
 from swarmrl.agents.agent import Agent
+from swarmrl.trainers.episodic_trainer import EpisodicTrainer
 from swarmrl.trainers.trainer import Trainer
 
 
@@ -25,3 +26,67 @@ def test_trainer_finalize_agents_delegates_to_agents():
 
     assert agent_0.finalize_calls == 1
     assert agent_1.finalize_calls == 1
+
+
+class _BoundaryAgent(Agent):
+    def __init__(self, particle_type=0):
+        self.particle_type = particle_type
+        self.boundaries = []
+        self.finalize_calls = 0
+
+    def on_rollout_end(self, *, terminated, truncated):
+        self.boundaries.append((terminated, truncated))
+        return [1.0]
+
+    def reset_agent(self, colloids):
+        pass
+
+    def finalize(self):
+        self.finalize_calls += 1
+
+
+class _Engine:
+    colloids = []
+
+    def integrate(self, episode_length, force_fn):
+        pass
+
+    def finalize(self):
+        pass
+
+
+def test_trainer_marks_requested_rollout_truncation_before_update():
+    agent = _BoundaryAgent()
+    trainer = Trainer([agent])
+
+    trainer.update_rl(truncated=True)
+
+    assert agent.boundaries == [(False, True)]
+
+
+def test_episodic_trainer_only_truncates_scheduled_reset_boundaries():
+    agent = _BoundaryAgent()
+    trainer = EpisodicTrainer([agent])
+
+    trainer.perform_rl_training(
+        get_engine=lambda system: _Engine(),
+        system=object(),
+        n_episodes=3,
+        episode_length=4,
+        reset_frequency=2,
+        load_bar=False,
+        save_episodic_data=False,
+    )
+
+    assert agent.boundaries == [(False, False), (False, True), (False, False)]
+
+
+def test_one_agent_termination_marks_all_agents_terminal():
+    terminating_agent = _BoundaryAgent(particle_type=0)
+    other_agent = _BoundaryAgent(particle_type=1)
+    trainer = Trainer([terminating_agent, other_agent])
+
+    trainer.update_rl(terminated=True)
+
+    assert terminating_agent.boundaries == [(True, False)]
+    assert other_agent.boundaries == [(True, False)]

--- a/CI/unit_tests/utils/test_storage_utils.py
+++ b/CI/unit_tests/utils/test_storage_utils.py
@@ -33,7 +33,12 @@ def _make_agent_trajectory(
     trajectory.rewards = np.full(
         (episode_length, n_colloids), base_value + 0.2, dtype=float
     )
-    trajectory.killed = bool(base_value > 5.0)
+    trajectory.terminated = np.zeros(episode_length, dtype=bool)
+    trajectory.truncated = np.zeros(episode_length, dtype=bool)
+    trajectory.terminated[-1] = bool(base_value > 5.0)
+    trajectory.final_observation = np.full(
+        (n_colloids, 1), base_value + 0.3, dtype=np.float32
+    )
     return trajectory
 
 
@@ -52,6 +57,9 @@ def _make_agent_trajectory_vector_features(
     )
     full_shape = (episode_length, n_colloids, *feature_shape)
     trajectory.features = np.full(full_shape, base_value, dtype=np.float32)
+    trajectory.final_observation = np.full(
+        (n_colloids, *feature_shape), base_value + 0.3, dtype=np.float32
+    )
     return trajectory
 
 
@@ -337,26 +345,50 @@ class TestStorageWriters:
             assert "log_probs" not in group
             assert "features" not in group
 
-    def test_agent_storage_persists_killed(self, tmp_path: Path):
+    def test_agent_storage_persists_transition_boundaries(self, tmp_path: Path):
         storage = AgentTrajectoryStorage(
-            particle_type=4,
+            particle_type=5,
             out_folder=str(tmp_path),
-            stored_attributes=["killed"],
+            stored_attributes=["terminated", "truncated", "final_observation"],
         )
         trajectory = _make_agent_trajectory(
-            4,
-            episode_length=3,
-            n_colloids=2,
-            base_value=6.0,
+            5, episode_length=3, n_colloids=2, base_value=6.0
         )
+        trajectory.truncated[:] = [False, True, False]
 
         storage.write(trajectory)
 
-        file_path = tmp_path / "agent_data_4.hdf5"
-        with h5py.File(file_path.as_posix(), "r") as h5_file:
-            group = h5_file["Agent_4"]
-            assert group["killed"].shape == (1, 1)
-            assert bool(group["killed"][0, 0]) is True
+        with h5py.File(tmp_path / "agent_data_5.hdf5", "r") as h5_file:
+            group = h5_file["Agent_5"]
+            npt.assert_array_equal(group["terminated"][0], trajectory.terminated)
+            npt.assert_array_equal(group["truncated"][0], trajectory.truncated)
+            npt.assert_allclose(
+                group["final_observation"][0], trajectory.final_observation
+            )
+
+    def test_agent_storage_pads_variable_length_trajectories(self, tmp_path: Path):
+        storage = AgentTrajectoryStorage(
+            particle_type=6,
+            out_folder=str(tmp_path),
+            preset="verbose",
+        )
+        full_rollout = _make_agent_trajectory(
+            6, episode_length=3, n_colloids=2, base_value=1.0
+        )
+        terminated_rollout = _make_agent_trajectory(
+            6, episode_length=1, n_colloids=2, base_value=7.0
+        )
+
+        storage.write(full_rollout)
+        storage.write(terminated_rollout)
+
+        with h5py.File(tmp_path / "agent_data_6.hdf5", "r") as h5_file:
+            group = h5_file["Agent_6"]
+            npt.assert_array_equal(group["trajectory_length"][:], [3, 1])
+            npt.assert_array_equal(group["terminated"][1], [True, False, False])
+            npt.assert_array_equal(
+                group["actions"][1, 0], terminated_rollout.actions[0]
+            )
 
     def test_sim_storage_batch_write_appends(self, tmp_path: Path):
         storage = SimulationTrajectoryStorage(

--- a/CI/unit_tests/utils/test_utils.py
+++ b/CI/unit_tests/utils/test_utils.py
@@ -2,7 +2,7 @@
 Test the utils module.
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
 
@@ -24,13 +24,13 @@ class TestUtils:
         Test the indices gathering function for even and odd numbers
         """
         # 5 particles, 3 time steps, 2 options
-        data = np.array([
+        data = jnp.array([
             [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]],
             [[10, 11], [12, 13], [14, 15], [16, 17], [18, 19]],
             [[20, 21], [22, 23], [24, 25], [26, 27], [28, 29]],
         ])
-        indices = np.array([[1, 1, 1, 1, 1], [0, 0, 0, 0, 0], [0, 0, 1, 1, 0]])
-        true_selection = np.array([
+        indices = jnp.array([[1, 1, 1, 1, 1], [0, 0, 0, 0, 0], [0, 0, 1, 1, 0]])
+        true_selection = jnp.array([
             [1, 3, 5, 7, 9],
             [10, 12, 14, 16, 18],
             [20, 22, 25, 27, 28],
@@ -40,33 +40,38 @@ class TestUtils:
         npt.assert_array_equal(test_selection, true_selection)
 
         # 2 particles, 3 time steps, 2 options
-        data = np.array([[[0, 1], [2, 3]], [[10, 11], [12, 13]], [[20, 21], [22, 23]]])
-        indices = np.array([[1, 1], [0, 0], [0, 0]])
-        true_selection = np.array([[1, 3], [10, 12], [20, 22]])
+        data = jnp.array([[[0, 1], [2, 3]], [[10, 11], [12, 13]], [[20, 21], [22, 23]]])
+        indices = jnp.array([[1, 1], [0, 0], [0, 0]])
+        true_selection = jnp.array([[1, 3], [10, 12], [20, 22]])
         test_selection = gather_n_dim_indices(data, indices)
         npt.assert_array_equal(test_selection, true_selection)
 
         # 3 particles, 4 time steps, 2 options
-        data = np.array([
+        data = jnp.array([
             [[0, 1], [2, 3], [4, 5]],
             [[10, 11], [12, 13], [14, 15]],
             [[20, 21], [22, 23], [24, 25]],
             [[30, 31], [32, 33], [34, 35]],
         ])
-        indices = np.array([[1, 1, 1], [0, 0, 0], [0, 0, 1], [1, 0, 1]])
-        true_selection = np.array([[1, 3, 5], [10, 12, 14], [20, 22, 25], [31, 32, 35]])
+        indices = jnp.array([[1, 1, 1], [0, 0, 0], [0, 0, 1], [1, 0, 1]])
+        true_selection = jnp.array([
+            [1, 3, 5],
+            [10, 12, 14],
+            [20, 22, 25],
+            [31, 32, 35],
+        ])
         test_selection = gather_n_dim_indices(data, indices)
         npt.assert_array_equal(test_selection, true_selection)
 
         # 4 particles, 4 time steps, 2 options
-        data = np.array([
+        data = jnp.array([
             [[0, 1], [2, 3], [4, 5], [6, 7]],
             [[10, 11], [12, 13], [14, 15], [16, 17]],
             [[20, 21], [22, 23], [24, 25], [26, 27]],
             [[30, 31], [32, 33], [34, 35], [36, 37]],
         ])
-        indices = np.array([[1, 1, 1, 0], [0, 0, 0, 1], [0, 0, 1, 1], [1, 0, 1, 1]])
-        true_selection = np.array([
+        indices = jnp.array([[1, 1, 1, 0], [0, 0, 0, 1], [0, 0, 1, 1], [1, 0, 1, 1]])
+        true_selection = jnp.array([
             [1, 3, 5, 6],
             [10, 12, 14, 17],
             [20, 22, 25, 27],
@@ -81,12 +86,12 @@ class TestUtils:
         for positiv and negativ angles in 2D
         """
 
-        my_director1 = np.array([1, 0, 0])
-        my_director2 = np.array([-1 / np.sqrt(2), -1 / np.sqrt(2), 0])
+        my_director1 = jnp.array([1, 0, 0])
+        my_director2 = jnp.array([-1 / jnp.sqrt(2), -1 / jnp.sqrt(2), 0])
 
-        other_director1 = np.array([1, 0, 0])
-        other_director2 = np.array([0, 1, 0])
-        other_director3 = np.array([1 / 2, np.sqrt(3) / 2, 0])
+        other_director1 = jnp.array([1, 0, 0])
+        other_director2 = jnp.array([0, 1, 0])
+        other_director3 = jnp.array([1 / 2, jnp.sqrt(3) / 2, 0])
 
         # test parallel and antiparallel case
         angle1 = calc_signed_angle_between_directors(my_director1, other_director1)
@@ -108,20 +113,20 @@ class TestUtils:
         )
 
         assert angle1 == 0
-        assert angle2 == pytest.approx(np.pi / 2)
-        assert angle3 == pytest.approx(np.pi / 3)
-        assert angle4 == pytest.approx(np.pi * 3 / 4)
-        assert angle5 == pytest.approx(-np.pi * 3 / 4)
-        assert abs(angle6 + np.pi * 11 / 12) < 10e-6
+        assert angle2 == pytest.approx(jnp.pi / 2)
+        assert angle3 == pytest.approx(jnp.pi / 3)
+        assert angle4 == pytest.approx(jnp.pi * 3 / 4)
+        assert angle5 == pytest.approx(-jnp.pi * 3 / 4)
+        assert abs(angle6 + jnp.pi * 11 / 12) < 10e-6
         assert abs(angle7 - angle3) < 10e-6
         assert abs(angle8 - angle6) < 10e-6
-        assert angle9 == pytest.approx(np.pi)
+        assert angle9 == pytest.approx(jnp.pi)
 
     def test_create_colloids(self):
         """
         Test the create_colloids function
         """
-        center = np.array([100, 100, 0])
+        center = jnp.array([100, 100, 0])
         dist = 300
         colloids_0 = create_colloids(
             n_cols=10,
@@ -133,8 +138,8 @@ class TestUtils:
         assert len(colloids_0) == 10
         for col in colloids_0:
             assert col.type == 0
-            npt.assert_almost_equal(np.linalg.norm(col.director), 1)
-            npt.assert_almost_equal(np.linalg.norm(col.pos - center), dist, decimal=3)
+            npt.assert_almost_equal(jnp.linalg.norm(col.director), 1)
+            npt.assert_almost_equal(jnp.linalg.norm(col.pos - center), dist, decimal=3)
 
         colloids_1 = create_colloids(
             n_cols=10,
@@ -147,9 +152,9 @@ class TestUtils:
         assert len(colloids_1) == 10
         for col in colloids_1:
             assert col.type == 1
-            npt.assert_almost_equal(np.linalg.norm(col.director), 1)
+            npt.assert_almost_equal(jnp.linalg.norm(col.director), 1)
             facing_dir = center - col.pos
-            facing_dir /= np.linalg.norm(facing_dir)
+            facing_dir /= jnp.linalg.norm(facing_dir)
             npt.assert_almost_equal(facing_dir, col.director, decimal=3)
 
     def test_ellipsoid_friction_factors(self):

--- a/CI/unit_tests/value_functions/test_expected_returns.py
+++ b/CI/unit_tests/value_functions/test_expected_returns.py
@@ -2,7 +2,7 @@
 Test the expected return module.
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from swarmrl.value_functions.expected_returns import ExpectedReturns
@@ -18,16 +18,34 @@ class TestExpectedReturns:
         Test that unstandardized returns work correctly.
         """
         # Sum over the rewards starting from index i, (0, 0), 1 + 2 + 3 and so on.
-        true_values = np.array([[6.0, 15.0], [5.0, 11.0], [3.0, 6.0]])
+        true_values = jnp.array([[6.0, 15.0], [5.0, 11.0], [3.0, 6.0]])
 
         # Trivial gamma function for analytic simplicity.
         value_function = ExpectedReturns(gamma=1.0, standardize=False)
 
         # 2 particles, 3 time steps
-        rewards = np.array([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
+        rewards = jnp.array([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
+        values = jnp.zeros((4, 2))
+        terminated = jnp.array([False, False, True])
+        truncated = jnp.zeros_like(terminated)
 
-        expected_returns = value_function(rewards)
+        expected_returns = value_function(rewards, values, terminated, truncated)
 
+        assert_array_equal(expected_returns, true_values)
+
+    def test_discounted_returns_with_non_unit_gamma(self):
+        """Test the exact discounted-return recurrence for gamma below one."""
+        value_function = ExpectedReturns(gamma=0.5, standardize=False)
+
+        rewards = jnp.array([[1.0], [2.0], [4.0]])
+        values = jnp.zeros((4, 1))
+        terminated = jnp.array([False, False, True])
+        truncated = jnp.zeros_like(terminated)
+
+        expected_returns = value_function(rewards, values, terminated, truncated)
+
+        # G_2 = 4, G_1 = 2 + 0.5 * 4, G_0 = 1 + 0.5 * G_1.
+        true_values = jnp.array([[3.0], [4.0], [4.0]])
         assert_array_equal(expected_returns, true_values)
 
     def test_standardized_returns(self):
@@ -37,11 +55,11 @@ class TestExpectedReturns:
         value_function = ExpectedReturns(gamma=0.79, standardize=True)
 
         # True values
-        true_mean = np.array([0.0, 0.0])
-        true_std = np.array([1.0, 1.0])
+        true_mean = jnp.array([0.0, 0.0])
+        true_std = jnp.array([1.0, 1.0])
 
         # 2 particles, 3 time steps
-        rewards = np.array([
+        rewards = jnp.array([
             [1.0, 4.0],
             [2.0, 5.0],
             [3.0, 6.0],
@@ -50,11 +68,47 @@ class TestExpectedReturns:
             [6.0, 9.0],
             [7.0, 10.0],
         ])
+        values = jnp.zeros((8, 2))
+        terminated = jnp.array([False] * 6 + [True])
+        truncated = jnp.zeros_like(terminated)
 
-        expected_returns = value_function(rewards)
+        expected_returns = value_function(rewards, values, terminated, truncated)
 
-        mean_vector = np.mean(expected_returns, axis=0)
-        std_vector = np.std(expected_returns, axis=0)
+        mean_vector = jnp.mean(expected_returns, axis=0)
+        std_vector = jnp.std(expected_returns, axis=0)
 
         assert_array_almost_equal(mean_vector, true_mean, decimal=6)
         assert_array_almost_equal(std_vector, true_std, decimal=6)
+
+    def test_rollout_boundary_bootstraps_from_final_value(self):
+        value_function = ExpectedReturns(gamma=1.0, standardize=False)
+        rewards = jnp.array([[1.0], [2.0]])
+        values = jnp.array([[0.0], [0.0], [10.0]])
+        terminated = jnp.array([False, False])
+        truncated = jnp.array([False, False])
+
+        returns = value_function(rewards, values, terminated, truncated)
+
+        assert_array_equal(returns, jnp.array([[13.0], [12.0]]))
+
+    def test_termination_zeros_bootstrap(self):
+        value_function = ExpectedReturns(gamma=1.0, standardize=False)
+        rewards = jnp.array([[1.0], [2.0]])
+        values = jnp.array([[0.0], [0.0], [10.0]])
+        terminated = jnp.array([False, True])
+        truncated = jnp.array([False, False])
+
+        returns = value_function(rewards, values, terminated, truncated)
+
+        assert_array_equal(returns, jnp.array([[3.0], [2.0]]))
+
+    def test_truncation_bootstraps_but_stops_return_propagation(self):
+        value_function = ExpectedReturns(gamma=1.0, standardize=False)
+        rewards = jnp.array([[1.0], [2.0], [3.0]])
+        values = jnp.array([[0.0], [10.0], [20.0], [30.0]])
+        terminated = jnp.array([False, False, False])
+        truncated = jnp.array([False, True, False])
+
+        returns = value_function(rewards, values, terminated, truncated)
+
+        assert_array_equal(returns, jnp.array([[23.0], [22.0], [33.0]]))

--- a/CI/unit_tests/value_functions/test_gae.py
+++ b/CI/unit_tests/value_functions/test_gae.py
@@ -1,4 +1,4 @@
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.value_functions.generalized_advantage_estimate import GAE
@@ -7,20 +7,55 @@ from swarmrl.value_functions.generalized_advantage_estimate import GAE
 class TestGAE:
     def test_gae(self):
         gae = GAE(gamma=1, lambda_=1)
-        rewards = np.array([1, 1, 1, 1, 1])
-        values = np.array([1, 2, 3, 4, 5])
+        rewards = jnp.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        values = jnp.array([1, 2, 3, 4, 5, 0])
+        terminated = jnp.array([False, False, False, False, True])
+        truncated = jnp.zeros_like(terminated)
 
-        expected_advantages = np.array([4, 2, 0, -2, -4])
+        expected_advantages = jnp.array([4, 2, 0, -2, -4])
 
-        expected_returns = expected_advantages + values
+        expected_returns = expected_advantages + values[:-1]
 
-        expected_advantages = (expected_advantages - np.mean(expected_advantages)) / (
-            np.std(expected_advantages) + np.finfo(np.float32).eps.item()
+        expected_advantages = (expected_advantages - jnp.mean(expected_advantages)) / (
+            jnp.std(expected_advantages) + jnp.finfo(jnp.float32).eps.item()
         )
 
-        advantages, returns = gae(rewards, values)
+        advantages, returns = gae(rewards, values, terminated, truncated)
 
         onp.testing.assert_allclose(
             advantages, expected_advantages, rtol=1e-4, atol=1e-4
         )
         onp.testing.assert_allclose(returns, expected_returns, rtol=1e-4, atol=1e-4)
+
+    def test_rollout_boundary_bootstraps_from_final_value(self):
+        gae = GAE(gamma=1, lambda_=1)
+        rewards = jnp.array([1.0, 1.0])
+        values = jnp.array([10.0, 20.0, 30.0])
+        terminated = jnp.array([False, False])
+        truncated = jnp.array([False, False])
+
+        _, returns = gae(rewards, values, terminated, truncated)
+
+        onp.testing.assert_allclose(returns, jnp.array([32.0, 31.0]))
+
+    def test_termination_zeros_bootstrap(self):
+        gae = GAE(gamma=1, lambda_=1)
+        rewards = jnp.array([1.0, 1.0])
+        values = jnp.array([10.0, 20.0, 30.0])
+        terminated = jnp.array([False, True])
+        truncated = jnp.array([False, False])
+
+        _, returns = gae(rewards, values, terminated, truncated)
+
+        onp.testing.assert_allclose(returns, jnp.array([2.0, 1.0]))
+
+    def test_truncation_bootstraps_but_stops_advantage_propagation(self):
+        gae = GAE(gamma=1, lambda_=1)
+        rewards = jnp.array([1.0, 2.0, 3.0])
+        values = jnp.array([0.0, 10.0, 20.0, 30.0])
+        terminated = jnp.array([False, False, False])
+        truncated = jnp.array([False, True, False])
+
+        _, returns = gae(rewards, values, terminated, truncated)
+
+        onp.testing.assert_allclose(returns, jnp.array([23.0, 22.0, 33.0]))

--- a/swarmrl/action_selection/action_selector.py
+++ b/swarmrl/action_selection/action_selector.py
@@ -1,7 +1,7 @@
 """Action selection orchestration for discrete and continuous stacks."""
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 
 from swarmrl.exploration_policies.exploration_policy import (
     ContinuousExplorationPolicy,
@@ -54,7 +54,7 @@ class ActionSelector:
 
     def select(
         self,
-        logits: np.ndarray,
+        logits: jnp.ndarray,
         deployment_mode: bool,
         sampling_key,
         exploration_key,
@@ -70,9 +70,9 @@ class ActionSelector:
                 indices = self.exploration_policy(
                     indices, logits.shape[-1], exploration_seed
                 )
-            expanded_indices = np.expand_dims(indices, axis=-1)
-            chosen_log_probs = np.take_along_axis(log_probs, expanded_indices, axis=-1)
-            chosen_log_probs = np.squeeze(chosen_log_probs, axis=-1)
+            expanded_indices = jnp.expand_dims(indices, axis=-1)
+            chosen_log_probs = jnp.take_along_axis(log_probs, expanded_indices, axis=-1)
+            chosen_log_probs = jnp.squeeze(chosen_log_probs, axis=-1)
 
             return indices, chosen_log_probs
 

--- a/swarmrl/agents/actor_critic.py
+++ b/swarmrl/agents/actor_critic.py
@@ -70,6 +70,7 @@ class ActorCriticAgent(Agent):
 
         # Trajectory to be updated.
         self.trajectory = TrajectoryInformation(particle_type=self.particle_type)
+        self._pending_observation = None
 
         self.storage_config = storage_config
         self.trajectory_storage = None
@@ -94,7 +95,7 @@ class ActorCriticAgent(Agent):
         """
         return "ActorCriticAgent"
 
-    def update_agent(self) -> tuple:
+    def update_agent(self):
         """
         Update the agents network.
 
@@ -102,13 +103,9 @@ class ActorCriticAgent(Agent):
         -------
         rewards : float
                 Net reward for the agent.
-        killed : bool
-                Whether or not this agent killed the
-                simulation.
         """
         # Collect data for returns.
         rewards = self.trajectory.rewards
-        killed = self.trajectory.killed
 
         # Compute loss for actor and critic.
         self.loss.compute_loss(
@@ -124,9 +121,20 @@ class ActorCriticAgent(Agent):
         self.persist_trajectory(self.trajectory)
 
         # Reset the trajectory storage.
-        self.reset_trajectory()
+        self.reset_trajectory(preserve_pending_observation=True)
 
-        return rewards, killed
+        return rewards
+
+    def on_rollout_end(self, *, terminated: bool, truncated: bool):
+        """Apply the shared-environment boundary and update the actor-critic model."""
+        if terminated or truncated:
+            if not self.trajectory.terminated:
+                raise ValueError("Cannot end an empty rollout.")
+
+            self.trajectory.terminated[-1] = terminated
+            self.trajectory.truncated[-1] = truncated and not terminated
+
+        return self.update_agent()
 
     def reset_agent(self, colloids: typing.List[Colloid]):
         """
@@ -139,15 +147,25 @@ class ActorCriticAgent(Agent):
         colloids : typing.List[Colloid]
                 Colloids to use in the initialization.
         """
+        self._pending_observation = None
         self.observable.initialize(colloids)
         self.task.initialize(colloids)
 
-    def reset_trajectory(self):
+    def reset_trajectory(self, preserve_pending_observation: bool = False):
         """
-        Set all trajectory data to None.
+        Clear the collected transition data.
+
+        Parameters
+        ----------
+        preserve_pending_observation : bool (default=False)
+            Preserve the final observation as the next rollout's (trainer episode's)
+            first observation when the environment continues across an optimizer
+            update.
         """
         self.task.kill_switch = False  # Reset here.
         self.trajectory = TrajectoryInformation(particle_type=self.particle_type)
+        if not preserve_pending_observation:
+            self._pending_observation = None
 
     def initialize_network(self):
         """
@@ -188,7 +206,11 @@ class ActorCriticAgent(Agent):
         colloids : List[Colloid]
                 List of colloids in the system.
         """
-        state_description = self.observable.compute_observable(colloids)
+        if self._pending_observation is None:
+            state_description = self.observable.compute_observable(colloids)
+        else:
+            state_description = self._pending_observation
+            self._pending_observation = None
         action_indices, log_probs = self.network.compute_action(
             observables=state_description
         )
@@ -201,7 +223,6 @@ class ActorCriticAgent(Agent):
             self.trajectory.features.append(state_description)
             self.trajectory.actions.append(action_indices)
             self.trajectory.log_probs.append(log_probs)
-            self.trajectory.killed = self.task.kill_switch
 
         self.kill_switch = self.task.kill_switch
 
@@ -236,5 +257,11 @@ class ActorCriticAgent(Agent):
         rewards += external_reward
         if self.train:
             self.trajectory.rewards.append(rewards)
+            terminated = bool(self.task.kill_switch)
+            self.trajectory.terminated.append(terminated)
+            self.trajectory.truncated.append(False)
+            final_observation = self.observable.compute_observable(colloids)
+            self.trajectory.final_observation = final_observation
+            self._pending_observation = final_observation
         self.kill_switch = self.task.kill_switch
         return rewards

--- a/swarmrl/agents/agent.py
+++ b/swarmrl/agents/agent.py
@@ -17,6 +17,15 @@ class Agent:
 
     _killed = False
 
+    def on_rollout_end(self, *, terminated: bool, truncated: bool) -> typing.Any | None:
+        """
+        Handle the end of a rollout (trainer episode).
+
+        Agents that learn from rollout data can override this hook to apply boundary
+        semantics and update themselves. Non-learning agents return ``None``.
+        """
+        return None
+
     def persist_trajectory(self, trajectory) -> None:
         """
         Persist trajectory data if a storage backend is attached.

--- a/swarmrl/components/swarm.py
+++ b/swarmrl/components/swarm.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import dataclasses
 from typing import List
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 from jax.tree_util import register_pytree_node_class
 
@@ -23,10 +23,10 @@ class Swarm:
     """
 
     # Colloid attributes
-    pos: np.ndarray
-    director: np.ndarray
+    pos: jnp.ndarray
+    director: jnp.ndarray
     id: int
-    velocity: np.ndarray = None
+    velocity: jnp.ndarray = None
     type: int = 0
 
     # Swarm attributes
@@ -75,11 +75,11 @@ class Swarm:
         """
         indices = self.type_indices[species]
         return Swarm(
-            pos=np.take(self.pos, indices, axis=0),
-            director=np.take(self.director, indices, axis=0),
-            id=np.take(self.id, indices, axis=0),
-            velocity=np.take(self.velocity, indices, axis=0),
-            type=np.take(self.type, indices, axis=0),
+            pos=jnp.take(self.pos, indices, axis=0),
+            director=jnp.take(self.director, indices, axis=0),
+            id=jnp.take(self.id, indices, axis=0),
+            velocity=jnp.take(self.velocity, indices, axis=0),
+            type=jnp.take(self.type, indices, axis=0),
             type_indices=None,
         )
 
@@ -115,20 +115,20 @@ def create_swarm(colloids: List[Colloid]) -> Swarm:
         Swarm object full of all colloids
     """
     # standard colloid attributes
-    pos = np.array([c.pos for c in colloids]).reshape(-1, colloids[0].pos.shape[0])
-    director = np.array([c.director for c in colloids]).reshape(
+    pos = jnp.array([c.pos for c in colloids]).reshape(-1, colloids[0].pos.shape[0])
+    director = jnp.array([c.director for c in colloids]).reshape(
         -1, colloids[0].director.shape[0]
     )
-    id = np.array([c.id for c in colloids]).reshape(-1, 1)
-    velocity = np.array([c.velocity for c in colloids]).reshape(
+    id = jnp.array([c.id for c in colloids]).reshape(-1, 1)
+    velocity = jnp.array([c.velocity for c in colloids]).reshape(
         -1, colloids[0].velocity.shape[0]
     )
-    type = np.array([c.type for c in colloids]).reshape(-1, 1)
+    type = jnp.array([c.type for c in colloids]).reshape(-1, 1)
 
     # add species indices to the colloid types.
     type_indices = {}
     types = onp.unique(type)
     for t in types:
-        type_indices[t] = np.array(get_colloid_indices(colloids, t))
+        type_indices[t] = jnp.array(get_colloid_indices(colloids, t))
 
     return Swarm(pos, director, id, velocity, type, type_indices)

--- a/swarmrl/engine/real_experiment.py
+++ b/swarmrl/engine/real_experiment.py
@@ -201,6 +201,8 @@ class RealExperiment(swarmrl.engine.engine.Engine):
             if reward_is_pending and force_model is not None:
                 force_model.calc_reward(colloids)
                 reward_is_pending = False
+                if force_model.kill_switch:
+                    break
 
             actions = self.get_actions(colloids, force_model)
             self.send_actions(actions)

--- a/swarmrl/exploration_policies/exploration_policy.py
+++ b/swarmrl/exploration_policies/exploration_policy.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 
 
 class ExplorationPolicy(ABC):
@@ -15,7 +15,7 @@ class ExplorationPolicy(ABC):
     """
 
     @abstractmethod
-    def __call__(self, *args: Any, **kwargs: Any) -> np.ndarray:
+    def __call__(self, *args: Any, **kwargs: Any) -> jnp.ndarray:
         """
         Apply exploration to model actions.
         """
@@ -29,14 +29,14 @@ class DiscreteExplorationPolicy(ExplorationPolicy, ABC):
 
     @abstractmethod
     def __call__(
-        self, model_actions: np.ndarray, action_space_length: int, seed: Any
-    ) -> np.ndarray:
+        self, model_actions: jnp.ndarray, action_space_length: int, seed: Any
+    ) -> jnp.ndarray:
         """
         Return an index associated with the chosen action.
 
         Parameters
         ----------
-        model_actions : np.ndarray (n_colloids,)
+        model_actions : jnp.ndarray (n_colloids,)
                 Action chosen by the model for each colloid.
         action_space_length : int
                 Number of possible actions. Should be 1 higher than the actual highest
@@ -44,7 +44,7 @@ class DiscreteExplorationPolicy(ExplorationPolicy, ABC):
 
         Returns
         -------
-        action : np.ndarray
+        action : jnp.ndarray
                 Action chosen after the exploration module has operated for
                 each colloid.
         """
@@ -58,21 +58,21 @@ class ContinuousExplorationPolicy(ExplorationPolicy, ABC):
 
     @abstractmethod
     def __call__(
-        self, model_actions: np.ndarray, rng_key: jax.random.PRNGKey
-    ) -> np.ndarray:
+        self, model_actions: jnp.ndarray, rng_key: jax.random.PRNGKey
+    ) -> jnp.ndarray:
         """
         Return an action value
 
         Parameters
         ----------
-        model_actions : np.ndarray (n_colloids,)
+        model_actions : jnp.ndarray (n_colloids,)
                 Action chosen by the model for each colloid.
         rng_key : jax.random.PRNGKey
                 Key for jax.random module
 
         Returns
         -------
-        action : np.ndarray
+        action : jnp.ndarray
                 Action chosen after the exploration module has operated.
         """
         raise NotImplementedError

--- a/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
+++ b/swarmrl/exploration_policies/ornstein_uhlenbeck_exploration.py
@@ -5,7 +5,7 @@ Global Ornstein-Uhlenbeck (OU) exploration for continuous actions.
 from typing import Any
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 
 from swarmrl.exploration_policies.exploration_policy import ContinuousExplorationPolicy
 
@@ -46,7 +46,7 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         long_term_mean: float = 0.0,
         action_dimension: int = 3,
         epsilon: float = 1.0,
-        float_precision: np.dtype = np.float32,
+        float_precision: jnp.dtype = jnp.float32,
     ) -> None:
         """
         Initialize the OU exploration process.
@@ -65,21 +65,23 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
             Number of continuous action dimensions.
         epsilon : float
             Probability of applying OU noise in a step. Must be > 0.
-        float_precision : np.dtype
+        float_precision : jnp.dtype
             Float precision to use for computations.
         """
         self.drift: float = float(drift)
         self.volatility: float = float(volatility)
-        self.long_term_mean: np.ndarray = np.asarray(
+        self.long_term_mean: jnp.ndarray = jnp.asarray(
             long_term_mean, dtype=float_precision
         )
         self.action_dimension: int = int(action_dimension)
-        self.action_limits: np.ndarray = np.asarray(
+        self.action_limits: jnp.ndarray = jnp.asarray(
             action_limits, dtype=float_precision
         )
-        self.noise: np.ndarray = np.zeros(self.action_dimension, dtype=float_precision)
-        self.epsilon: np.ndarray = np.asarray(epsilon, dtype=float_precision)
-        self.float_precision: np.dtype = float_precision
+        self.noise: jnp.ndarray = jnp.zeros(
+            self.action_dimension, dtype=float_precision
+        )
+        self.epsilon: jnp.ndarray = jnp.asarray(epsilon, dtype=float_precision)
+        self.float_precision: jnp.dtype = float_precision
 
         if self.drift <= 0:
             raise ValueError("drift needs to be greater than 0")
@@ -96,13 +98,13 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         """
         Reduce OU state magnitude and epsilon (called every 10 episodes by trainer).
         """
-        decay = np.asarray(decay, dtype=self.float_precision)
+        decay = jnp.asarray(decay, dtype=self.float_precision)
         self.noise = self.noise * decay
-        self.epsilon = np.maximum(self.epsilon * decay, self.float_precision(0.01))
+        self.epsilon = jnp.maximum(self.epsilon * decay, self.float_precision(0.01))
 
     def __call__(
-        self, model_actions: np.ndarray, rng_key: jax.random.PRNGKey
-    ) -> np.ndarray:
+        self, model_actions: jnp.ndarray, rng_key: jax.random.PRNGKey
+    ) -> jnp.ndarray:
         """
         Add OU noise to model actions.
 
@@ -110,7 +112,7 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
         to the current action output. Gating is dimension-wise (independent per
         action component), not one shared gate for the whole action vector.
         """
-        model_actions = np.asarray(model_actions, dtype=self.float_precision)
+        model_actions = jnp.asarray(model_actions, dtype=self.float_precision)
         key_normal, key_uniform = jax.random.split(rng_key)
 
         value_range = self.action_limits[:, 1] - self.action_limits[:, 0]
@@ -140,5 +142,5 @@ class GlobalOUExploration(ContinuousExplorationPolicy):
             noise_to_apply = noise_to_apply.reshape(1, -1)
 
         actions = model_actions + noise_to_apply
-        actions = np.clip(actions, self.action_limits[:, 0], self.action_limits[:, 1])
+        actions = jnp.clip(actions, self.action_limits[:, 0], self.action_limits[:, 1])
         return actions

--- a/swarmrl/exploration_policies/random_exploration.py
+++ b/swarmrl/exploration_policies/random_exploration.py
@@ -5,7 +5,7 @@ Random exploration module.
 from functools import partial
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 
 from swarmrl.exploration_policies.exploration_policy import DiscreteExplorationPolicy
 
@@ -29,14 +29,14 @@ class RandomExploration(DiscreteExplorationPolicy):
 
     @partial(jax.jit, static_argnums=(0,))
     def __call__(
-        self, model_actions: np.ndarray, action_space_length: int, seed
-    ) -> np.ndarray:
+        self, model_actions: jnp.ndarray, action_space_length: int, seed
+    ) -> jnp.ndarray:
         """
         Return an index associated with the chosen action.
 
         Parameters
         ----------
-        model_actions : np.ndarray (n_colloids,)
+        model_actions : jnp.ndarray (n_colloids,)
                 Action chosen by the model for each colloid.
         action_space_length : int
                 Number of possible actions. Should be 1 higher than the actual highest
@@ -44,16 +44,16 @@ class RandomExploration(DiscreteExplorationPolicy):
 
         Returns
         -------
-        action : np.ndarray
+        action : jnp.ndarray
                 Action chosen after the exploration module has operated for
                 each colloid.
         """
         key = jax.random.PRNGKey(seed)
         sample = jax.random.uniform(key, shape=model_actions.shape)
 
-        to_be_changed = np.clip(sample - self.probability, min=0, max=1)
-        to_be_changed = np.clip(to_be_changed * 1e6, min=0, max=1)
-        not_to_be_changed = np.clip(to_be_changed * -10 + 1, 0, 1)
+        to_be_changed = jnp.clip(sample - self.probability, min=0, max=1)
+        to_be_changed = jnp.clip(to_be_changed * 1e6, min=0, max=1)
+        not_to_be_changed = jnp.clip(to_be_changed * -10 + 1, 0, 1)
 
         # Choose random actions
         key, subkey = jax.random.split(key)
@@ -67,6 +67,6 @@ class RandomExploration(DiscreteExplorationPolicy):
         # Put the new actions in.
         model_actions = (
             model_actions * to_be_changed + exploration_actions * not_to_be_changed
-        ).astype(np.int16)
+        ).astype(jnp.int16)
 
         return model_actions

--- a/swarmrl/force_functions/force_fn.py
+++ b/swarmrl/force_functions/force_fn.py
@@ -89,7 +89,10 @@ class ForceFunction:
         self, colloids: typing.List[Colloid], external_reward: float = 0.0
     ) -> None:
         """
-        Compute the reward for the agent based on the current state.
+        Compute rewards and immediately aggregate task termination signals.
+
+        Immediate propagation ensures that the engine stops before selecting a
+        post-terminal action.
 
         Parameters
         ----------
@@ -100,7 +103,13 @@ class ForceFunction:
 
         """
 
+        switches = []
         for agent in self.agents:
             self.agents[agent].calc_reward(
                 colloids=colloids, external_reward=external_reward
             )
+            switches.append(self.agents[agent].kill_switch)
+
+        # Tasks can terminate the environment while computing rewards. Propagate the
+        # agent status immediately so the engine stops before selecting another action.
+        self.kill_switch = any(switches)

--- a/swarmrl/intrinsic_reward/intrinsic_reward.py
+++ b/swarmrl/intrinsic_reward/intrinsic_reward.py
@@ -4,7 +4,7 @@ Module for the intrinsic reward parent class.
 
 from abc import ABC
 
-import jax.numpy as np
+import jax.numpy as jnp
 
 from swarmrl.utils.colloid_utils import TrajectoryInformation
 
@@ -25,7 +25,7 @@ class IntrinsicReward(ABC):
         """
         raise NotImplementedError("Implemented in child class.")
 
-    def compute_reward(self, episode_data: TrajectoryInformation) -> np.ndarray:
+    def compute_reward(self, episode_data: TrajectoryInformation) -> jnp.ndarray:
         """
         Compute the intrinsic reward.
 

--- a/swarmrl/intrinsic_reward/random_network_distillation.py
+++ b/swarmrl/intrinsic_reward/random_network_distillation.py
@@ -6,7 +6,7 @@ Notes
 https://arxiv.org/abs/1810.12894
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 from znnl.models.flax_model import FlaxModel
 from znnl.models.jax_model import JaxModel
 
@@ -55,7 +55,7 @@ class RNDReward(IntrinsicReward):
         self.training_strategy.set_model(self.predictor_network)
 
     @staticmethod
-    def _reshape_data(x: np.ndarray) -> np.ndarray:
+    def _reshape_data(x: jnp.ndarray) -> jnp.ndarray:
         """
         Reshape the data for an equal treatment of time and ensemble.
 
@@ -66,28 +66,28 @@ class RNDReward(IntrinsicReward):
 
         Parameters
         ----------
-        data : np.ndarray of shape (n_steps, num_colloids, num_features)
+        data : jnp.ndarray of shape (n_steps, num_colloids, num_features)
                 Data to be reshaped.
 
         Returns
         -------
-        reshaped_data : np.ndarray of shape (n_steps * num_colloids, num_features)
+        reshaped_data : jnp.ndarray of shape (n_steps * num_colloids, num_features)
                 Reshaped data.
         """
-        return np.reshape(x, (-1, *np.shape(x)[2:]))
+        return jnp.reshape(x, (-1, *jnp.shape(x)[2:]))
 
-    def compute_distance(self, points: np.ndarray) -> np.ndarray:
+    def compute_distance(self, points: jnp.ndarray) -> jnp.ndarray:
         """
         Compute the distance between neural network representations.
 
         Parameters
         ----------
-        points : np.ndarray of shape (1, num_points, num_features)
+        points : jnp.ndarray of shape (1, num_points, num_features)
                 Points on which distances should be computed.
 
         Returns
         -------
-        distances : np.ndarray
+        distances : jnp.ndarray
                 A tensor of distances computed using the attached metric.
         """
         x = self._reshape_data(points)
@@ -97,7 +97,7 @@ class RNDReward(IntrinsicReward):
         self.metric_results = self.distance_metric(
             target_predictions, predictor_predictions
         )
-        return np.mean(self.metric_results)
+        return jnp.mean(self.metric_results)
 
     def update(self, episode_data: TrajectoryInformation):
         """
@@ -122,7 +122,7 @@ class RNDReward(IntrinsicReward):
             **self.training_kwargs,
         )
 
-    def compute_reward(self, episode_data: TrajectoryInformation) -> np.ndarray:
+    def compute_reward(self, episode_data: TrajectoryInformation) -> jnp.ndarray:
         """
         Compute the intrinsic reward of the last state of the episode using RND.
 
@@ -133,11 +133,11 @@ class RNDReward(IntrinsicReward):
 
         Returns
         -------
-        Reward : np.ndarray of shape (num_colloids, )
+        Reward : jnp.ndarray of shape (num_colloids, )
                 Reward for the current state.
         """
         points = episode_data.features[-1:]
         metric_results = self.compute_distance(points=points)
         if self.clip_rewards is not None:
-            metric_results = np.clip(metric_results, *self.clip_rewards)
+            metric_results = jnp.clip(metric_results, *self.clip_rewards)
         return metric_results

--- a/swarmrl/losses/loss.py
+++ b/swarmrl/losses/loss.py
@@ -2,7 +2,7 @@
 Module for the loss parent class.
 """
 
-import jax.numpy as np
+import jax.numpy as jnp
 
 from swarmrl.networks.network import Network
 
@@ -15,7 +15,7 @@ class Loss:
     def compute_loss(
         self,
         network: Network,
-        episode_data: np.ndarray,
+        episode_data: jnp.ndarray,
     ):
         """
         Compute loss on models.

--- a/swarmrl/losses/policy_gradient_loss.py
+++ b/swarmrl/losses/policy_gradient_loss.py
@@ -46,10 +46,13 @@ class PolicyGradientLoss(Loss):
         self,
         network_params: FrozenDict,
         network: Network,
-        feature_data: jnp.ndarray,
-        action_indices: jnp.ndarray,
-        rewards: jnp.ndarray,
-    ) -> jnp.array:
+        feature_data: jax.Array,
+        action_indices: jax.Array,
+        rewards: jax.Array,
+        final_observation: jax.Array,
+        terminated: jax.Array,
+        truncated: jax.Array,
+    ) -> jax.Array:
         """
         Compute the loss of the shared actor-critic network.
 
@@ -59,13 +62,20 @@ class PolicyGradientLoss(Loss):
             The actor-critic network that approximates the policy.
         network_params : FrozenDict
             Parameters of the actor-critic model used.
-        feature_data : np.ndarray (n_time_steps, n_particles, feature_dimension)
+        feature_data : jax.Array (n_time_steps, n_particles, feature_dimension)
             Observable data for each time step and particle within the episode.
-        action_indices : np.ndarray (n_time_steps, n_particles)
+        action_indices : jax.Array (n_time_steps, n_particles)
             The actions taken by the policy for all time steps and particles during one
             episode.
-        rewards : np.ndarray (n_time_steps, n_particles)
+        rewards : jax.Array (n_time_steps, n_particles)
             The rewards received for all time steps and particles during one episode.
+        final_observation : jax.Array (n_particles, feature_dimension)
+            Observation reached after the final transition, used only to bootstrap
+            the critic and not associated with an action or reward.
+        terminated : jax.Array (n_time_steps,)
+            Per-transition task termination flags.
+        truncated : jax.Array (n_time_steps,)
+            Per-transition environment-reset or time-limit flags.
 
 
         Returns
@@ -74,15 +84,24 @@ class PolicyGradientLoss(Loss):
             The loss of the actor-critic network for the last episode.
         """
 
-        # (n_timesteps, n_particles, n_possibilities)
-        logits, predicted_values = network(network_params, feature_data)
-        predicted_values = predicted_values.squeeze()
-        probabilities = jax.nn.softmax(logits)  # get probabilities
+        # Include the resulting final state for critic bootstrapping.
+        # Shape: (n_timesteps + 1, n_particles, feature_dimension).
+        all_feature_data = jnp.concatenate(
+            (feature_data, final_observation[jnp.newaxis, ...]), axis=0
+        )
+        all_logits, all_values = network(network_params, all_feature_data)
+        logits = all_logits[:-1]
+        all_values = jnp.squeeze(all_values, axis=-1)
+        predicted_values = all_values[:-1]
+        probabilities = jax.nn.softmax(logits, axis=-1)  # get probabilities
         chosen_probabilities = gather_n_dim_indices(probabilities, action_indices)
         log_probs = jnp.log(chosen_probabilities + 1e-8)
         log_jax_runtime_value("log_probs", log_probs)
 
-        returns = self.value_function(rewards)
+        returns = self.value_function(rewards, all_values, terminated, truncated)
+        # Necessary because bootstrapped returns contain critic values; the targets
+        # must not receive gradients during the critic update.
+        returns = jax.lax.stop_gradient(returns)
         log_jax_runtime_value("returns", returns)
 
         log_jax_runtime_value("predicted_values", predicted_values)
@@ -109,7 +128,8 @@ class PolicyGradientLoss(Loss):
         network : Network
                 actor-critic model to use in the analysis.
         episode_data : np.ndarray (n_timesteps, n_particles, feature_dimension)
-                Observable data for each time step and particle within the episode.
+                Observable data for each action state. The final observation is stored
+                separately in ``episode_data.final_observation``.
 
         Returns
         -------
@@ -121,6 +141,9 @@ class PolicyGradientLoss(Loss):
         feature_data = jnp.array(episode_data.features)
         action_data = jnp.array(episode_data.actions)
         reward_data = jnp.array(episode_data.rewards)
+        final_observation = jnp.array(episode_data.final_observation)
+        terminated = jnp.array(episode_data.terminated, dtype=bool)
+        truncated = jnp.array(episode_data.truncated, dtype=bool)
 
         self.n_particles = jnp.shape(feature_data)[1]
         self.n_time_steps = jnp.shape(feature_data)[0]
@@ -132,6 +155,9 @@ class PolicyGradientLoss(Loss):
             feature_data=feature_data,
             action_indices=action_data,
             rewards=reward_data,
+            final_observation=final_observation,
+            terminated=terminated,
+            truncated=truncated,
         )
 
         network.update_model(network_grads)

--- a/swarmrl/losses/proximal_policy_loss.py
+++ b/swarmrl/losses/proximal_policy_loss.py
@@ -65,11 +65,14 @@ class ProximalPolicyLoss(Loss, ABC):
         self,
         network_params: FrozenDict,
         network: Network,
-        feature_data,
-        action_indices,
-        rewards,
-        old_log_probs,
-    ) -> jnp.array:
+        feature_data: jax.Array,
+        action_indices: jax.Array,
+        rewards: jax.Array,
+        old_log_probs: jax.Array,
+        final_observation: jax.Array,
+        terminated: jax.Array,
+        truncated: jax.Array,
+    ) -> jax.Array:
         """
         A function that computes the actor loss.
 
@@ -79,16 +82,23 @@ class ProximalPolicyLoss(Loss, ABC):
             The actor-critic network that approximates the policy.
         network_params : FrozenDict
             Parameters of the actor-critic model used.
-        feature_data : np.ndarray (n_time_steps, n_particles, feature_dimension)
+        feature_data : jax.Array (n_time_steps, n_particles, feature_dimension)
             Observable data for each time step and particle within the episode.
-        action_indices : np.ndarray (n_time_steps, n_particles)
+        action_indices : jax.Array (n_time_steps, n_particles)
             The actions taken by the policy for all time steps and particles during one
             episode.
-        rewards : np.ndarray (n_time_steps, n_particles)
+        rewards : jax.Array (n_time_steps, n_particles)
             The rewards received for all time steps and particles during one episode.
-        old_log_probs : np.ndarray (n_time_steps, n_particles)
+        old_log_probs : jax.Array (n_time_steps, n_particles)
             The log probabilities of the actions taken by the policy for all time steps
             and particles during one episode.
+        final_observation : jax.Array (n_particles, feature_dimension)
+            Observation reached after the final transition, used only to bootstrap
+            the critic and not associated with an action or reward.
+        terminated : jax.Array (n_time_steps,)
+            Per-transition task termination flags.
+        truncated : jax.Array (n_time_steps,)
+            Per-transition environment-reset or time-limit flags.
 
         Returns
         -------
@@ -96,16 +106,26 @@ class ProximalPolicyLoss(Loss, ABC):
             The loss of the actor-critic network for the last episode.
         """
 
+        # Include the resulting final state for critic bootstrapping. It has no action.
+        all_feature_data = jnp.concatenate(
+            (feature_data, final_observation[jnp.newaxis, ...]), axis=0
+        )
         # compute the probabilities of the old actions under the new policy
-        new_logits, predicted_values = network(network_params, feature_data)
-        predicted_values = predicted_values.squeeze()
+        all_logits, all_values = network(network_params, all_feature_data)
+        new_logits = all_logits[:-1]
+        all_values = jnp.squeeze(all_values, axis=-1)
+        predicted_values = all_values[:-1]
 
         log_jax_runtime_value("predicted_values", predicted_values)
 
         # compute the advantages and returns
         advantages, returns = self.value_function(
-            rewards=rewards, values=predicted_values
+            rewards=rewards,
+            values=all_values,
+            terminated=terminated,
+            truncated=truncated,
         )
+        returns = jax.lax.stop_gradient(returns)
         log_jax_runtime_value("advantages", advantages)
         log_jax_runtime_value("returns", returns)
 
@@ -154,7 +174,8 @@ class ProximalPolicyLoss(Loss, ABC):
         network : Network
                 actor-critic model to use in the analysis.
         episode_data : np.ndarray (n_timesteps, n_particles, feature_dimension)
-                Observable data for each time step and particle within the episode.
+                Observable data for each action state. The final observation is stored
+                separately in ``episode_data.final_observation``.
 
         Returns
         -------
@@ -164,6 +185,9 @@ class ProximalPolicyLoss(Loss, ABC):
         feature_data = jnp.array(episode_data.features)
         action_data = jnp.array(episode_data.actions)
         reward_data = jnp.array(episode_data.rewards)
+        final_observation = jnp.array(episode_data.final_observation)
+        terminated = jnp.array(episode_data.terminated, dtype=bool)
+        truncated = jnp.array(episode_data.truncated, dtype=bool)
 
         for _ in range(self.n_epochs):
             network_grad_fn = jax.value_and_grad(self._calculate_loss)
@@ -174,6 +198,9 @@ class ProximalPolicyLoss(Loss, ABC):
                 action_indices=action_data,
                 rewards=reward_data,
                 old_log_probs=old_log_probs_data,
+                final_observation=final_observation,
+                terminated=terminated,
+                truncated=truncated,
             )
 
             network.update_model(network_grad)

--- a/swarmrl/networks/flax_network.py
+++ b/swarmrl/networks/flax_network.py
@@ -8,7 +8,7 @@ from abc import ABC
 from typing import List
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 from flax import linen as nn
 from flax.core.frozen_dict import FrozenDict
@@ -122,7 +122,7 @@ class FlaxModel(Network, ABC):
                 initial state of model to then be trained.
                 If you have multiple optimizers, this will create a custom train state.
         """
-        params = self.model.init(init_rng, np.ones(list(self.input_shape)))["params"]
+        params = self.model.init(init_rng, jnp.ones(list(self.input_shape)))["params"]
 
         if isinstance(self.optimizer, dict):
             CustomTrainState = self._create_custom_train_state(self.optimizer)
@@ -176,7 +176,7 @@ class FlaxModel(Network, ABC):
 
         Returns
         -------
-        tuple : (np.ndarray, Optional[np.ndarray])
+        tuple : (jnp.ndarray, Optional[jnp.ndarray])
                 Discrete mode:
                     ``(indices, chosen_log_probs)``, where chosen log-probs
                     (softmaxed network output) are gathered from ``log softmax(logits)``
@@ -193,11 +193,11 @@ class FlaxModel(Network, ABC):
         # Compute state
         try:
             logits, _ = self.apply_fn(
-                {"params": self.model_state.params}, np.array(observables)
+                {"params": self.model_state.params}, jnp.array(observables)
             )
         except AttributeError:  # We need this for loaded models.
             logits, _ = self.apply_fn(
-                {"params": self.model_state["params"]}, np.array(observables)
+                {"params": self.model_state["params"]}, jnp.array(observables)
             )
         logger.debug(f"{logits=}")  # (n_colloids, n_actions)
         sampling_key = self._next_rng_key()
@@ -269,14 +269,14 @@ class FlaxModel(Network, ABC):
         ----------
         parmas : dict
                 Parameters of the model.
-        episode_features: np.ndarray (n_steps, n_agents, observable_dimension)
+        episode_features: jnp.ndarray (n_steps, n_agents, observable_dimension)
                 Features of the episode. This contains the features of all agents,
                 for all time steps in the episode.
 
 
         Returns
         -------
-        logits : np.ndarray
+        logits : jnp.ndarray
                 Output of the network.
         """
 

--- a/swarmrl/networks/network.py
+++ b/swarmrl/networks/network.py
@@ -4,7 +4,7 @@ Parent class for the networks.
 
 from typing import List
 
-import jax.numpy as np
+import jax.numpy as jnp
 from flax.core.frozen_dict import FrozenDict
 
 from swarmrl.components.colloid import Colloid
@@ -36,7 +36,7 @@ class Network:
         """
         raise NotImplementedError("Implemented in child class.")
 
-    def __call__(self, params: FrozenDict, feature_vector: np.ndarray):
+    def __call__(self, params: FrozenDict, feature_vector: jnp.ndarray):
         """
         Perform the forward pass on the model. This method is
         used in the update. It uses a vmapped version of the
@@ -46,7 +46,7 @@ class Network:
         ----------
         params : FrozenDict
                 Parameters of the model.
-        feature_vector : np.ndarray
+        feature_vector : jnp.ndarray
                 Current state of the agent on which actions should be made.
 
         Returns

--- a/swarmrl/observables/concentration_field.py
+++ b/swarmrl/observables/concentration_field.py
@@ -9,7 +9,7 @@ Observable for sensing changes in some field value, or, the gradient.
 from abc import ABC
 from typing import List
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.components.colloid import Colloid
@@ -29,9 +29,9 @@ class ConcentrationField(Observable, ABC):
 
     def __init__(
         self,
-        source: np.ndarray,
+        source: jnp.ndarray,
         decay_fn: callable,
-        box_length: np.ndarray,
+        box_length: jnp.ndarray,
         scale_factor: int = 100,
         particle_type: int = 0,
         return_absolute: bool = False,
@@ -41,11 +41,11 @@ class ConcentrationField(Observable, ABC):
 
         Parameters
         ----------
-        source : np.ndarray
+        source : jnp.ndarray
                 Source of the field.
         decay_fn : callable
                 Decay function of the field.
-        box_size : np.ndarray
+        box_size : jnp.ndarray
                 Array for scaling of the distances.
         scale_factor : int (default=100)
                 Scaling factor for the observable.
@@ -102,8 +102,8 @@ class ConcentrationField(Observable, ABC):
         # Update historic position.
         self._historic_positions[str(index)] = position
 
-        current_distance = np.linalg.norm(self.source - position)
-        historic_distance = np.linalg.norm(self.source - previous_position)
+        current_distance = jnp.linalg.norm(self.source - position)
+        historic_distance = jnp.linalg.norm(self.source - previous_position)
 
         current_value = self.decay_fn(current_distance)
         historic_value = self.decay_fn(historic_distance)
@@ -143,4 +143,4 @@ class ConcentrationField(Observable, ABC):
             self.compute_single_observable(index, colloids) for index in reference_ids
         ]
 
-        return np.array(observables).reshape(-1, 1)
+        return jnp.array(observables).reshape(-1, 1)

--- a/swarmrl/observables/particle_sensing.py
+++ b/swarmrl/observables/particle_sensing.py
@@ -5,7 +5,7 @@ Observable for particle sensing.
 from typing import List
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.components.colloid import Colloid
@@ -20,7 +20,7 @@ class ParticleSensing(Observable):
     def __init__(
         self,
         decay_fn: callable,
-        box_length: np.ndarray,
+        box_length: jnp.ndarray,
         sensing_type: int = 0,
         scale_factor: int = 100,
         particle_type: int = 0,
@@ -33,7 +33,7 @@ class ParticleSensing(Observable):
         ----------
         decay_fn : callable
                 Decay function of the field.
-        box_size : np.ndarray
+        box_size : jnp.ndarray
                 Array for scaling of the distances.
         sensing_type : int (default=0)
                 Type of particle to sense.
@@ -75,7 +75,7 @@ class ParticleSensing(Observable):
         Updates the class state.
         """
         reference_ids = self.get_colloid_indices(colloids)
-        historic_values = np.zeros(len(reference_ids))
+        historic_values = jnp.zeros(len(reference_ids))
 
         positions = []
         indices = []
@@ -83,12 +83,12 @@ class ParticleSensing(Observable):
             indices.append(colloids[index].id)
             positions.append(colloids[index].pos)
 
-        sensed_colloids = np.array([
+        sensed_colloids = jnp.array([
             colloid.pos for colloid in colloids if colloid.type == self.sensing_type
         ])
 
         out_indices, _, field_values = self.observable_fn(
-            np.array(indices), np.array(positions), sensed_colloids, historic_values
+            jnp.array(indices), jnp.array(positions), sensed_colloids, historic_values
         )
 
         for index, value in zip(out_indices, onp.array(field_values)):
@@ -97,8 +97,8 @@ class ParticleSensing(Observable):
     def compute_single_observable(
         self,
         index: int,
-        reference_position: np.ndarray,
-        test_positions: np.ndarray,
+        reference_position: jnp.ndarray,
+        test_positions: jnp.ndarray,
         historic_value: float,
     ) -> tuple:
         """
@@ -108,9 +108,9 @@ class ParticleSensing(Observable):
         ----------
         index : int
                 Index of the colloid to compute the observable for.
-        reference_position : np.ndarray (3,)
+        reference_position : jnp.ndarray (3,)
                 Position of the reference colloid.
-        test_positions : np.ndarray (n_colloids, 3)
+        test_positions : jnp.ndarray (n_colloids, 3)
                 Positions of the test colloids.
         historic_value : float
                 Historic value of the observable.
@@ -123,11 +123,11 @@ class ParticleSensing(Observable):
         observable_value : float
                 Value of the observable.
         """
-        distances = np.linalg.norm(
+        distances = jnp.linalg.norm(
             (test_positions - reference_position) / self.box_length, axis=-1
         )
-        indices = np.asarray(np.nonzero(distances, size=distances.shape[0] - 1))
-        distances = np.take(distances, indices, axis=0)
+        indices = jnp.asarray(jnp.nonzero(distances, size=distances.shape[0] - 1))
+        distances = jnp.take(distances, indices, axis=0)
         # Compute field value
         field_value = self.decay_fn(distances).sum()
         observable_value = self.transform_value(
@@ -168,15 +168,15 @@ class ParticleSensing(Observable):
             positions.append(colloids[index].pos)
             historic_values.append(self.historical_field[str(colloids[index].id)])
 
-        test_points = np.array([
+        test_points = jnp.array([
             colloid.pos for colloid in colloids if colloid.type == self.sensing_type
         ])
 
         out_indices, observable_values, field_values = self.observable_fn(
-            np.array(indices),
-            np.array(positions),
+            jnp.array(indices),
+            jnp.array(positions),
             test_points,
-            np.array(historic_values),
+            jnp.array(historic_values),
         )
 
         for index, value in zip(out_indices, onp.array(field_values)):

--- a/swarmrl/observables/position.py
+++ b/swarmrl/observables/position.py
@@ -5,7 +5,7 @@ Position observable computer.
 from abc import ABC
 from typing import List
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.components.colloid import Colloid
@@ -17,13 +17,13 @@ class PositionObservable(Observable, ABC):
     Position in box observable.
     """
 
-    def __init__(self, box_length: np.ndarray, particle_type: int = 0):
+    def __init__(self, box_length: jnp.ndarray, particle_type: int = 0):
         """
         Constructor for the observable.
 
         Parameters
         ----------
-        box_length : np.ndarray
+        box_length : jnp.ndarray
                 Length of the box with which to normalize.
         """
         super().__init__(particle_type=particle_type)
@@ -44,7 +44,7 @@ class PositionObservable(Observable, ABC):
 
         data = onp.copy(colloid.pos)
 
-        return np.array(data) / self.box_length
+        return jnp.array(data) / self.box_length
 
     def compute_observable(self, colloids: List[Colloid]):
         """

--- a/swarmrl/sampling_strategies/categorical_distribution.py
+++ b/swarmrl/sampling_strategies/categorical_distribution.py
@@ -5,7 +5,7 @@ Module for the categorical distribution.
 from abc import ABC
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.sampling_strategies.sampling_strategy import DiscreteSamplingStrategy
@@ -39,20 +39,20 @@ class CategoricalDistribution(DiscreteSamplingStrategy, ABC):
             )
             raise KeyError(msg)
 
-    def __call__(self, logits: np.ndarray, rng_key=None) -> np.ndarray:
+    def __call__(self, logits: jnp.ndarray, rng_key=None) -> jnp.ndarray:
         """
         Sample from the distribution.
 
         Parameters
         ----------
-        logits : np.ndarray (n_colloids, n_dimensions)
+        logits : jnp.ndarray (n_colloids, n_dimensions)
                 Logits from the model to use in the computation for all colloids.
         rng_key : Optional[jax.Array]
                 PRNG key for sampling. If ``None``, a random fallback key is created.
 
         Returns
         -------
-        indices : np.ndarray (n_colloids,)
+        indices : jnp.ndarray (n_colloids,)
                 Index of the selected option in the distribution.
         """
         rng = (

--- a/swarmrl/sampling_strategies/gumbel_distribution.py
+++ b/swarmrl/sampling_strategies/gumbel_distribution.py
@@ -5,7 +5,7 @@ Module for the Gumbel distribution.
 from abc import ABC
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.sampling_strategies.sampling_strategy import DiscreteSamplingStrategy
@@ -16,20 +16,20 @@ class GumbelDistribution(DiscreteSamplingStrategy, ABC):
     Class for the Gumbel distribution.
     """
 
-    def __call__(self, logits: np.ndarray, rng_key=None) -> np.ndarray:
+    def __call__(self, logits: jnp.ndarray, rng_key=None) -> jnp.ndarray:
         """
         Sample from the distribution.
 
         Parameters
         ----------
-        logits : np.ndarray (n_colloids, n_dimensions)
+        logits : jnp.ndarray (n_colloids, n_dimensions)
                 Logits from the model to use in the computation for all colloids.
         rng_key : Optional[jax.Array]
                 PRNG key for sampling. If ``None``, a random fallback key is created.
 
         Returns
         -------
-        indices : np.ndarray (n_colloids,)
+        indices : jnp.ndarray (n_colloids,)
                 Indices of chosen actions for all colloids.
 
         Notes
@@ -43,6 +43,6 @@ class GumbelDistribution(DiscreteSamplingStrategy, ABC):
         )
         noise = jax.random.uniform(rng, shape=logits.shape)
 
-        indices = np.argmax(logits - np.log(-np.log(noise)), axis=-1)
+        indices = jnp.argmax(logits - jnp.log(-jnp.log(noise)), axis=-1)
 
         return indices

--- a/swarmrl/sampling_strategies/sampling_strategy.py
+++ b/swarmrl/sampling_strategies/sampling_strategy.py
@@ -5,7 +5,7 @@ Parent class for sampling strategies.
 from abc import ABC, abstractmethod
 from typing import Any
 
-import jax.numpy as np
+import jax.numpy as jnp
 
 
 class SamplingStrategy(ABC):
@@ -13,27 +13,27 @@ class SamplingStrategy(ABC):
     Parent class for sampling strategies.
     """
 
-    def compute_entropy(self, probabilities: np.ndarray) -> float:
+    def compute_entropy(self, probabilities: jnp.ndarray) -> float:
         """
         Compute the Shannon entropy of the probabilities.
 
         Parameters
         ----------
-        probabilities : np.ndarray (n_colloids, n_actions)
+        probabilities : jnp.ndarray (n_colloids, n_actions)
                 Probabilities for each colloid to take specific actions.
         """
         eps = 1e-8
         probabilities += eps
-        return -np.sum(probabilities * np.log(probabilities))
+        return -jnp.sum(probabilities * jnp.log(probabilities))
 
     @abstractmethod
-    def __call__(self, logits: np.ndarray) -> Any:
+    def __call__(self, logits: jnp.ndarray) -> Any:
         """
         Sample from the distribution.
 
         Parameters
         ----------
-        logits : np.ndarray (n_colloids, n_dimensions)
+        logits : jnp.ndarray (n_colloids, n_dimensions)
                 Logits from the model to use in the computation for each colloid.
 
         Returns

--- a/swarmrl/tasks/multi_tasking.py
+++ b/swarmrl/tasks/multi_tasking.py
@@ -4,7 +4,7 @@ Class for multi-tasking.
 
 from typing import List
 
-import jax.numpy as np
+import jax.numpy as jnp
 
 from swarmrl.components import Colloid
 from swarmrl.tasks.task import Task
@@ -40,7 +40,7 @@ class MultiTasking(Task):
         for item in self.tasks:
             item.initialize(colloids)
 
-    def __call__(self, colloids: List[Colloid]) -> np.ndarray:
+    def __call__(self, colloids: List[Colloid]) -> jnp.ndarray:
         """
         Computes all observables and returns them in a concatenated list.
 
@@ -50,11 +50,11 @@ class MultiTasking(Task):
 
         Returns
         -------
-        rewards : np.ndarray of shape (num_colloids, )
+        rewards : jnp.ndarray of shape (num_colloids, )
                 Array of rewards for each colloid.
         """
         species_indices = self.get_colloid_indices(colloids)
-        rewards = np.zeros(len(species_indices))
+        rewards = jnp.zeros(len(species_indices))
         for task in self.tasks:
             ts = task(colloids)
             rewards += ts

--- a/swarmrl/tasks/object_movement/rod_rotation.py
+++ b/swarmrl/tasks/object_movement/rod_rotation.py
@@ -5,7 +5,7 @@ Class for rod rotation task.
 from typing import List
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.components.colloid import Colloid
@@ -55,7 +55,7 @@ class RotateRod(Task):
             angular_velocity_scale *= -1  # CW is negative
 
         self.angular_velocity_scale = angular_velocity_scale
-        self._velocity_history = np.full(velocity_history_size, np.nan)
+        self._velocity_history = jnp.full(velocity_history_size, jnp.nan)
 
         self.decomp_fn = jax.jit(compute_torque_on_rod)
 
@@ -75,19 +75,19 @@ class RotateRod(Task):
         -------
         Updates the class state.
         """
-        self._velocity_history = np.full(self.velocity_history_size, np.nan)
+        self._velocity_history = jnp.full(self.velocity_history_size, jnp.nan)
         for item in colloids:
             if item.type == self.rod_type:
                 self._historic_rod_director = onp.copy(item.director)
                 break
 
-    def _compute_angular_velocity(self, new_director: np.ndarray):
+    def _compute_angular_velocity(self, new_director: jnp.ndarray):
         """
         Compute the instantaneous angular velocity of the rod.
 
         Parameters
         ----------
-        new_director : np.ndarray (3, )
+        new_director : jnp.ndarray (3, )
                 New rod director.
 
         Returns
@@ -95,32 +95,32 @@ class RotateRod(Task):
         angular_velocity : float
                 Angular velocity of the rod
         """
-        angular_velocity = np.arctan2(
-            np.cross(self._historic_rod_director[:2], new_director[:2]),
-            np.dot(self._historic_rod_director[:2], new_director[:2]),
+        angular_velocity = jnp.arctan2(
+            jnp.cross(self._historic_rod_director[:2], new_director[:2]),
+            jnp.dot(self._historic_rod_director[:2], new_director[:2]),
         )
 
         # Convert to degrees for better scaling.
-        angular_velocity = np.rad2deg(angular_velocity)
+        angular_velocity = jnp.rad2deg(angular_velocity)
 
         # Update the historical rod director and velocity.
         self._historic_rod_director = new_director
 
-        self._velocity_history = np.roll(self._velocity_history, -1)
+        self._velocity_history = jnp.roll(self._velocity_history, -1)
         self._velocity_history = self._velocity_history.at[-1].set(angular_velocity)
 
         # Return the scaled average velocity. nanmean ignores the not-yet-filled
         # entries so the mean is unbiased before the history buffer is full.
-        return self.angular_velocity_scale * np.nanmean(self._velocity_history)
+        return self.angular_velocity_scale * jnp.nanmean(self._velocity_history)
 
     def partition_reward(
         self,
         reward: float,
-        colloid_positions: np.ndarray,
-        colloid_directors: np.ndarray,
-        rod_positions: np.ndarray,
-        rod_directors: np.ndarray,
-    ) -> np.ndarray:
+        colloid_positions: jnp.ndarray,
+        colloid_directors: jnp.ndarray,
+        rod_positions: jnp.ndarray,
+        rod_directors: jnp.ndarray,
+    ) -> jnp.ndarray:
         """
         Partition a reward into colloid contributions.
 
@@ -128,18 +128,18 @@ class RotateRod(Task):
         ----------
         reward : float
                 Reward to be partitioned.
-        colloid_positions : np.ndarray (n_colloids, 3)
+        colloid_positions : jnp.ndarray (n_colloids, 3)
                 Positions of the colloids.
-        colloid_directors : np.ndarray (n_colloids, 3)
+        colloid_directors : jnp.ndarray (n_colloids, 3)
                 Directors of the colloids.
-        rod_positions : np.ndarray (n_rod, 3)
+        rod_positions : jnp.ndarray (n_rod, 3)
                 Positions of the rod particles.
-        rod_directors : np.ndarray (n_rod, 3)
+        rod_directors : jnp.ndarray (n_rod, 3)
                 Directors of the rod particles.
 
         Returns
         -------
-        partitioned_reward : np.ndarray (n_colloids, )
+        partitioned_reward : jnp.ndarray (n_colloids, )
                 Partitioned reward for each colloid.
         """
         if self.partition:
@@ -148,30 +148,30 @@ class RotateRod(Task):
             )
         else:
             colloid_partitions = (
-                np.ones(colloid_positions.shape[0]) / colloid_positions.shape[0]
+                jnp.ones(colloid_positions.shape[0]) / colloid_positions.shape[0]
             )
 
         return reward * colloid_partitions
 
     def _compute_angular_velocity_reward(
         self,
-        rod_directors: np.ndarray,
-        rod_positions: np.ndarray,
-        colloid_positions: np.ndarray,
-        colloid_directors: np.ndarray,
+        rod_directors: jnp.ndarray,
+        rod_positions: jnp.ndarray,
+        colloid_positions: jnp.ndarray,
+        colloid_directors: jnp.ndarray,
     ):
         """
         Compute the angular velocity reward.
 
         Parameters
         ----------
-        rod_directors : np.ndarray (n_rod, 3)
+        rod_directors : jnp.ndarray (n_rod, 3)
                 Directors of the rod particles.
-        rod_positions : np.ndarray (n_rod, 3)
+        rod_positions : jnp.ndarray (n_rod, 3)
                 Positions of the rod particles.
-        colloid_positions : np.ndarray (n_colloids, 3)
+        colloid_positions : jnp.ndarray (n_colloids, 3)
                 Positions of the colloids.
-        colloid_directors : np.ndarray (n_colloids, 3)
+        colloid_directors : jnp.ndarray (n_colloids, 3)
                 Directors of the colloids.
 
         Returns
@@ -210,14 +210,14 @@ class RotateRod(Task):
         """
         # Collect the important data.
         rod = [colloid for colloid in colloids if colloid.type == self.rod_type]
-        rod_positions = np.array([colloid.pos for colloid in rod])
-        rod_directors = np.array([colloid.director for colloid in rod])
+        rod_positions = jnp.array([colloid.pos for colloid in rod])
+        rod_directors = jnp.array([colloid.director for colloid in rod])
 
         chosen_colloids = [
             colloid for colloid in colloids if colloid.type == self.particle_type
         ]
-        colloid_positions = np.array([colloid.pos for colloid in chosen_colloids])
-        colloid_directors = np.array([colloid.director for colloid in chosen_colloids])
+        colloid_positions = jnp.array([colloid.pos for colloid in chosen_colloids])
+        colloid_directors = jnp.array([colloid.director for colloid in chosen_colloids])
 
         # Compute the angular velocity reward
         angular_velocity_term = self._compute_angular_velocity_reward(

--- a/swarmrl/tasks/object_movement/rod_torque.py
+++ b/swarmrl/tasks/object_movement/rod_torque.py
@@ -5,7 +5,7 @@ Class for rod rotation task.
 from typing import List
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.components.colloid import Colloid
@@ -60,7 +60,7 @@ class RodTorque(Task):
             angular_velocity_scale *= -1  # CW is negative
 
         self.angular_velocity_scale = angular_velocity_scale
-        self._velocity_history_list = np.full(velocity_history_size, np.nan)
+        self._velocity_history_list = jnp.full(velocity_history_size, jnp.nan)
 
         self.decomp_fn = jax.jit(compute_torque_partition_on_rod)
 
@@ -80,7 +80,7 @@ class RodTorque(Task):
         -------
         Updates the class state.
         """
-        self._velocity_history_list = np.full(self.velocity_history_size, np.nan)
+        self._velocity_history_list = jnp.full(self.velocity_history_size, jnp.nan)
         for item in colloids:
             if item.type == self.rod_type:
                 self._historic_rod_director = onp.copy(item.director)
@@ -88,25 +88,25 @@ class RodTorque(Task):
 
     def _compute_torque_on_rod(
         self,
-        rod_positions: np.ndarray,
-        colloid_directors: np.ndarray,
-        colloid_positions: np.ndarray,
-    ) -> np.ndarray:
+        rod_positions: jnp.ndarray,
+        colloid_directors: jnp.ndarray,
+        colloid_positions: jnp.ndarray,
+    ) -> jnp.ndarray:
         """
         Compute the torques on the rod.
 
         Parameters
         ----------
-        rod_positions : np.ndarray (n_rod, 3)
+        rod_positions : jnp.ndarray (n_rod, 3)
                 Positions of the rod particles.
-        colloid_directors : np.ndarray (n_colloids, 3)
+        colloid_directors : jnp.ndarray (n_colloids, 3)
                 Directors of the colloids.
-        colloid_positions : np.ndarray (n_colloids, 3)
+        colloid_positions : jnp.ndarray (n_colloids, 3)
                 Positions of the colloids.
 
         Returns
         -------
-        torques : np.ndarray (n_colloids, )
+        torques : jnp.ndarray (n_colloids, )
                 Torques on the rod for each colloid.
         """
         torques = self.decomp_fn(rod_positions, colloid_directors, colloid_positions)[
@@ -114,14 +114,14 @@ class RodTorque(Task):
         ]
         return torques
 
-    def _compute_angular_velocity(self, new_director: np.ndarray):
+    def _compute_angular_velocity(self, new_director: jnp.ndarray):
         """
         Compute the average angular velocity of the rod. This gets clipped,
         so that negative values become 0.
 
         Parameters
         ----------
-        new_director : np.ndarray (3, )
+        new_director : jnp.ndarray (3, )
                 New rod director.
 
         Returns
@@ -129,17 +129,17 @@ class RodTorque(Task):
         angular_velocity : float
                 Angular velocity of the rod
         """
-        angular_velocity = np.arctan2(
-            np.cross(self._historic_rod_director[:2], new_director[:2]),
-            np.dot(self._historic_rod_director[:2], new_director[:2]),
+        angular_velocity = jnp.arctan2(
+            jnp.cross(self._historic_rod_director[:2], new_director[:2]),
+            jnp.dot(self._historic_rod_director[:2], new_director[:2]),
         )
 
         # Convert to degree for easier handling
-        angular_velocity = np.rad2deg(angular_velocity)
+        angular_velocity = jnp.rad2deg(angular_velocity)
 
         # Update the historical rod director and velocity.
         self._historic_rod_director = new_director
-        self._velocity_history_list = np.roll(self._velocity_history_list, -1)
+        self._velocity_history_list = jnp.roll(self._velocity_history_list, -1)
         self._velocity_history_list = self._velocity_history_list.at[-1].set(
             angular_velocity
         )
@@ -147,37 +147,37 @@ class RodTorque(Task):
         # Return the clipped average velocity. nanmean ignores the not-yet-filled
         # entries so the mean is unbiased before the history buffer is full.
         if self.angular_velocity_scale > 0.0:
-            return np.clip(np.nanmean(self._velocity_history_list), 0.0, None)
+            return jnp.clip(jnp.nanmean(self._velocity_history_list), 0.0, None)
         else:
-            return np.clip(np.nanmean(self._velocity_history_list), None, 0.0)
+            return jnp.clip(jnp.nanmean(self._velocity_history_list), None, 0.0)
 
     def sort_out_opposite_direction_torques(
         self,
-        colloid_torques_on_rod: np.ndarray,
-    ) -> np.ndarray:
+        colloid_torques_on_rod: jnp.ndarray,
+    ) -> jnp.ndarray:
         """
         Remove rewards for torque in the wrong direction.
 
         Parameters
         ----------
-        colloid_torque_on_rod : np.ndarray (n_colloids, )
+        colloid_torque_on_rod : jnp.ndarray (n_colloids, )
                 Torques of the colloids on the rod.
 
         Returns
         -------
-        torques_in_direction : np.ndarray (n_colloids, )
+        torques_in_direction : jnp.ndarray (n_colloids, )
                 Torques on the rod for each colloid with wrong directions set to 0.
         """
         # Sign of the torques has to be inverted to avoid negative rewards.
-        sign = np.sign(self.angular_velocity_scale)
-        return np.clip(-sign * colloid_torques_on_rod, 0.0, None) * sign
+        sign = jnp.sign(self.angular_velocity_scale)
+        return jnp.clip(-sign * colloid_torques_on_rod, 0.0, None) * sign
 
     def _compute_torque_and_velocity_reward(
         self,
-        rod_directors: np.ndarray,
-        rod_positions: np.ndarray,
-        colloid_directors: np.ndarray,
-        colloid_positions: np.ndarray,
+        rod_directors: jnp.ndarray,
+        rod_positions: jnp.ndarray,
+        colloid_directors: jnp.ndarray,
+        colloid_positions: jnp.ndarray,
     ):
         """
         Get the torques, the turning velocity and apply the scaling.
@@ -187,18 +187,18 @@ class RodTorque(Task):
 
         Parameters
         ----------
-        rod_directors : np.ndarray (n_rod, 3)
+        rod_directors : jnp.ndarray (n_rod, 3)
                 Directors of the rod.
-        rod_positions : np.ndarray (n_rod, 3)
+        rod_positions : jnp.ndarray (n_rod, 3)
                 Positions of the rod particles.
-        colloid_directors : np.ndarray (n_colloids, 3)
+        colloid_directors : jnp.ndarray (n_colloids, 3)
                 Directors of the colloids.
-        colloid_positions : np.ndarray (n_rod, 3)
+        colloid_positions : jnp.ndarray (n_rod, 3)
                 Positions of the colloids.
 
         Returns
         -------
-        rewards : np.ndarray (n_colloids, )
+        rewards : jnp.ndarray (n_colloids, )
                 Rewards for each colloid.
         """
 
@@ -226,12 +226,12 @@ class RodTorque(Task):
         """
         # Collect the important data.
         rod_data = [(c.pos, c.director) for c in colloids if c.type == self.rod_type]
-        rod_positions, rod_directors = map(np.array, zip(*rod_data))
+        rod_positions, rod_directors = map(jnp.array, zip(*rod_data))
 
         colloid_data = [
             (c.pos, c.director) for c in colloids if c.type == self.particle_type
         ]
-        colloid_positions, colloid_directors = map(np.array, zip(*colloid_data))
+        colloid_positions, colloid_directors = map(jnp.array, zip(*colloid_data))
 
         rewards = self._compute_torque_and_velocity_reward(
             rod_directors, rod_positions, colloid_directors, colloid_positions

--- a/swarmrl/tasks/searching/gradient_sensing.py
+++ b/swarmrl/tasks/searching/gradient_sensing.py
@@ -11,7 +11,7 @@ Requires a warm up step.
 from abc import ABC
 from typing import List
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.components.colloid import Colloid
@@ -25,9 +25,9 @@ class GradientSensing(Task, ABC):
 
     def __init__(
         self,
-        source: np.ndarray = np.array([0, 0, 0]),
+        source: jnp.ndarray = jnp.array([0, 0, 0]),
         decay_function: callable = None,
-        box_length: np.ndarray = np.array([1.0, 1.0, 0.0]),
+        box_length: jnp.ndarray = jnp.array([1.0, 1.0, 0.0]),
         reward_scale_factor: int = 10,
         particle_type: int = 0,
     ):
@@ -36,13 +36,13 @@ class GradientSensing(Task, ABC):
 
         Parameters
         ----------
-        source : np.ndarray (default = (0, 0 0))
+        source : jnp.ndarray (default = (0, 0 0))
                 Source of the gradient.
         decay_function : callable (required=True)
                 A function that describes the decay of the field along one dimension.
                 This cannot be left None. The function should take a distance from the
                 source and return the magnitude of the field at this point.
-        box_length : np.ndarray
+        box_length : jnp.ndarray
                 Side length of the box.
         reward_scale_factor : int (default=10)
                 The amount the field is scaled by to get the reward.
@@ -78,13 +78,13 @@ class GradientSensing(Task, ABC):
                 position = onp.copy(item.pos) / self.box_length
                 self._historic_positions[str(index)] = position
 
-    def change_source(self, new_source: np.ndarray):
+    def change_source(self, new_source: jnp.ndarray):
         """
         Changes the concentration field source.
 
         Parameters
         ----------
-        new_source : np.ndarray
+        new_source : jnp.ndarray
                 Coordinates of the new source.
         """
         self.source = new_source
@@ -111,14 +111,14 @@ class GradientSensing(Task, ABC):
         old_position = self._historic_positions[str(colloid_id)]
 
         # Compute the distance from the source
-        current_distance = np.linalg.norm(current_position - self.source)
-        old_distance = np.linalg.norm(old_position - self.source)
+        current_distance = jnp.linalg.norm(current_position - self.source)
+        old_distance = jnp.linalg.norm(old_position - self.source)
 
         # Compute difference in scaled_distances
         delta = self.decay_fn(current_distance) - self.decay_fn(old_distance)
 
         # Compute the reward
-        reward = np.clip(self.reward_scale_factor * delta, 0.0, None)
+        reward = jnp.clip(self.reward_scale_factor * delta, 0.0, None)
 
         # Update the historic position
         self._historic_positions[str(colloid_id)] = current_position
@@ -145,6 +145,6 @@ class GradientSensing(Task, ABC):
         """
         colloid_indices = self.get_colloid_indices(colloids)
 
-        return np.array([
+        return jnp.array([
             self.compute_colloid_reward(index, colloids) for index in colloid_indices
         ])

--- a/swarmrl/tasks/searching/species_search.py
+++ b/swarmrl/tasks/searching/species_search.py
@@ -5,7 +5,7 @@ Class for the species search task.
 from typing import List
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 
 from swarmrl.components.colloid import Colloid
@@ -20,7 +20,7 @@ class SpeciesSearch(Task):
     def __init__(
         self,
         decay_fn: callable,
-        box_length: np.ndarray,
+        box_length: jnp.ndarray,
         sensing_type: int = 0,
         avoid: bool = False,
         scale_factor: int = 100,
@@ -34,7 +34,7 @@ class SpeciesSearch(Task):
         ----------
         decay_fn : callable
                 Decay function of the field.
-        box_size : np.ndarray
+        box_size : jnp.ndarray
                 Array for scaling of the distances.
         sensing_type : int (default=0)
                 Type of particle to sense.
@@ -77,7 +77,7 @@ class SpeciesSearch(Task):
         Updates the class state.
         """
         reference_ids = self.get_colloid_indices(colloids)
-        historic_values = np.zeros(len(reference_ids))
+        historic_values = jnp.zeros(len(reference_ids))
 
         positions = []
         indices = []
@@ -85,12 +85,12 @@ class SpeciesSearch(Task):
             indices.append(colloids[index].id)
             positions.append(colloids[index].pos)
 
-        test_points = np.array([
+        test_points = jnp.array([
             colloid.pos for colloid in colloids if colloid.type == self.sensing_type
         ])
 
         out_indices, _, field_values = self.task_fn(
-            np.array(indices), np.array(positions), test_points, historic_values
+            jnp.array(indices), jnp.array(positions), test_points, historic_values
         )
 
         for index, value in zip(out_indices, onp.array(field_values)):
@@ -99,8 +99,8 @@ class SpeciesSearch(Task):
     def compute_single_particle_task(
         self,
         index: int,
-        reference_position: np.ndarray,
-        test_positions: np.ndarray,
+        reference_position: jnp.ndarray,
+        test_positions: jnp.ndarray,
         historic_value: float,
     ) -> tuple:
         """
@@ -110,9 +110,9 @@ class SpeciesSearch(Task):
         ----------
         index : int
                 Index of the colloid to compute the observable for.
-        reference_position : np.ndarray (3,)
+        reference_position : jnp.ndarray (3,)
                 Position of the reference colloid.
-        test_positions : np.ndarray (n_colloids, 3)
+        test_positions : jnp.ndarray (n_colloids, 3)
                 Positions of the test colloids.
         historic_value : float
                 Historic value of the observable.
@@ -125,7 +125,7 @@ class SpeciesSearch(Task):
         task_value : float
                 Value of the task.
         """
-        distances = np.linalg.norm(
+        distances = jnp.linalg.norm(
             (test_positions - reference_position) / self.box_length, axis=-1
         )
 
@@ -133,7 +133,7 @@ class SpeciesSearch(Task):
         if self.sensing_type == self.particle_type:
             include_mask = distances > 0
         else:
-            include_mask = np.ones_like(distances, dtype=bool)
+            include_mask = jnp.ones_like(distances, dtype=bool)
 
         field_terms = self.decay_fn(distances) * include_mask.astype(distances.dtype)
         field_value = field_terms.sum()
@@ -175,23 +175,23 @@ class SpeciesSearch(Task):
             positions.append(colloids[index].pos)
             historic_values.append(self.historical_field[str(colloids[index].id)])
 
-        test_points = np.array([
+        test_points = jnp.array([
             colloid.pos for colloid in colloids if colloid.type == self.sensing_type
         ])
 
         out_indices, task_values, field_values = self.task_fn(
-            np.array(indices),
-            np.array(positions),
+            jnp.array(indices),
+            jnp.array(positions),
             test_points,
-            np.array(historic_values),
+            jnp.array(historic_values),
         )
 
         for index, value in zip(out_indices, onp.array(field_values)):
             self.historical_field[str(index)] = value
 
         if self.avoid:
-            rewards = np.clip(task_values, None, 0)
+            rewards = jnp.clip(task_values, None, 0)
         else:
-            rewards = np.clip(task_values, 0, None)
+            rewards = jnp.clip(task_values, 0, None)
 
         return self.scale_factor * rewards

--- a/swarmrl/tasks/task.py
+++ b/swarmrl/tasks/task.py
@@ -33,14 +33,19 @@ class Task:
     @property
     def kill_switch(self):
         """
-        Kill switch property of the task
+        Hard environment-termination signal.
+
+        When a task sets this signal while computing a reward, the current time slice
+        is completed and its transition is recorded with ``terminated=True``. The
+        engine stops before selecting another action. Episodic training resets the
+        environment; continuous training ends.
         """
         return self._kill_switch
 
     @kill_switch.setter
     def kill_switch(self, value: bool):
         """
-        Set the kill switch property.
+        Set the hard environment-termination signal.
 
         Parameters
         ----------

--- a/swarmrl/trainers/continuous_trainer.py
+++ b/swarmrl/trainers/continuous_trainer.py
@@ -40,6 +40,11 @@ class ContinuousTrainer(Trainer):
                 Number of time steps in one episode.
         load_bar : bool (default=True)
                 If true, show a progress bar.
+
+        Notes
+        -----
+        If a task terminates the environment, the current rollout ends immediately and
+        continuous training stops rather than resetting the environment.
         """
         self.engine = system_runner
         rewards = np.zeros(n_episodes)
@@ -74,7 +79,9 @@ class ContinuousTrainer(Trainer):
             stop_after_episode = -1
             for episode in range(n_episodes):
                 self.engine.integrate(episode_length, force_fn)
-                force_fn, current_reward, killed = self.update_rl()
+                force_fn, current_reward, killed = self.update_rl(
+                    terminated=force_fn.kill_switch
+                )
                 rewards[episode] = current_reward
                 completed_episodes = episode + 1
 

--- a/swarmrl/trainers/episodic_trainer.py
+++ b/swarmrl/trainers/episodic_trainer.py
@@ -63,8 +63,9 @@ class EpisodicTrainer(Trainer):
 
         Notes
         -----
-        If you are using semi-episodic training but your task kills the
-        simulation, the system will be reset.
+        If a task terminates the environment, the current rollout ends immediately and
+        the environment is reset before the next rollout. This also applies during
+        semi-episodic training.
         """
         killed = False
         rewards = np.zeros(n_episodes)
@@ -120,7 +121,11 @@ class EpisodicTrainer(Trainer):
 
                 self.engine.integrate(episode_length, force_fn)
 
-                force_fn, current_reward, killed = self.update_rl()
+                reset_after_rollout = (episode + 1) % reset_frequency == 0
+                terminated = force_fn.kill_switch
+                force_fn, current_reward, killed = self.update_rl(
+                    terminated=terminated, truncated=reset_after_rollout
+                )
 
                 rewards[episode] = current_reward
                 self.maybe_save_checkpoint(rewards, episode, current_reward)

--- a/swarmrl/trainers/trainer.py
+++ b/swarmrl/trainers/trainer.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 import numpy as np
 from loguru import logger
 
-from swarmrl.agents.actor_critic import ActorCriticAgent
+from swarmrl.agents.agent import Agent
 from swarmrl.checkpointers.base_checkpointer import BaseCheckpointer
 from swarmrl.checkpointers.checkpoint_manager import CheckpointManager
 from swarmrl.force_functions.force_fn import ForceFunction
@@ -43,7 +43,7 @@ class Trainer:
 
     def __init__(
         self,
-        agents: List[ActorCriticAgent],
+        agents: List[Agent],
         checkpointers: List[BaseCheckpointer] | None = None,
     ):
         """
@@ -108,9 +108,19 @@ class Trainer:
             agents=self.agents,
         )
 
-    def update_rl(self) -> Tuple[ForceFunction, np.ndarray]:
+    def update_rl(
+        self, terminated: bool = False, truncated: bool = False
+    ) -> Tuple[ForceFunction, np.ndarray, bool]:
         """
         Update the RL algorithm.
+
+        Parameters
+        ----------
+        truncated : bool
+                Whether the environment will be reset after this rollout (trainer
+                episode).
+        terminated : bool
+                Whether a task ended the shared environment during this rollout.
 
         Returns
         -------
@@ -120,20 +130,29 @@ class Trainer:
                 Current mean episode reward. This is returned for nice progress bars.
         killed : bool
                 Whether or not the task has ended the training.
+
+        Notes
+        -----
+        A rollout is one SwarmRL trainer episode between network updates. A truncated
+        rollout ends because the environment will be reset; a terminated rollout ends
+        because a task has ended the shared environment. Termination takes precedence
+        when both occur at the same rollout boundary. Because all agents share that
+        environment, termination is applied to every agent's final transition.
         """
         reward = 0.0  # TODO: Separate between species and optimize visualization.
-        switches = []
-
+        truncated = truncated and not terminated
         for agent in self.agents.values():
-            if isinstance(agent, ActorCriticAgent):
-                ag_reward, ag_killed = agent.update_agent()
-                logger.debug(f"{ag_reward=}")
-                reward += np.mean(ag_reward)
-                switches.append(ag_killed)
+            agent_rewards = agent.on_rollout_end(
+                terminated=terminated,
+                truncated=truncated,
+            )
+            if agent_rewards is not None:
+                logger.debug(f"agent rewards={agent_rewards}")
+                reward += np.mean(agent_rewards)
 
         # Create a new interaction model.
         interaction_model = ForceFunction(agents=self.agents)
-        return interaction_model, np.array(reward), any(switches)
+        return interaction_model, np.array(reward), terminated
 
     def finalize_agents(self):
         """Finalize agent-side resources after training."""

--- a/swarmrl/training_routines/genetic_algorithm.py
+++ b/swarmrl/training_routines/genetic_algorithm.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import List
 
-import jax.numpy as np
+import jax.numpy as jnp
 import numpy as onp
 from dask.distributed import Client, LocalCluster, wait
 from dask_jobqueue import JobQueueCluster
@@ -103,7 +103,7 @@ class GeneticTraining:
         # Decide on parent splits
         self.identifiers = range(population_size)
 
-        lazy_splits = np.array_split(np.ones(population_size), number_of_parents)
+        lazy_splits = jnp.array_split(jnp.ones(population_size), number_of_parents)
         self.split_lengths = [len(split) for split in lazy_splits]
 
         # set the select function
@@ -268,13 +268,13 @@ class GeneticTraining:
 
         return generation_outputs
 
-    def _select_parents(self, generation_outputs: np.ndarray) -> list:
+    def _select_parents(self, generation_outputs: jnp.ndarray) -> list:
         """
         Select the parents for the next generation.
 
         Parameters
         ----------
-        generation_outputs : np.ndarray (n_individuals, )
+        generation_outputs : jnp.ndarray (n_individuals, )
             The outputs of the generation.
 
         Returns
@@ -288,7 +288,7 @@ class GeneticTraining:
         ids = [item[1] for item in generation_outputs]
 
         # First get best parent
-        max_reward_index = np.argmax(np.array(rewards))
+        max_reward_index = jnp.argmax(jnp.array(rewards))
         chosen_id = ids[max_reward_index]
 
         # Pick mutations

--- a/swarmrl/utils/colloid_utils.py
+++ b/swarmrl/utils/colloid_utils.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 class TrajectoryInformation:
     """
     Helper dataclass for training RL models.
+
+    Features, actions, rewards, and boundary flags contain one entry per transition.
+    ``final_observation`` is the observation reached after the final transition. It
+    has no corresponding action or reward and is used only for value bootstrapping.
     """
 
     particle_type: int
@@ -23,7 +27,9 @@ class TrajectoryInformation:
     actions: list = field(default_factory=list)
     log_probs: list = field(default_factory=list)
     rewards: list = field(default_factory=list)
-    killed: bool = False
+    terminated: list = field(default_factory=list)
+    truncated: list = field(default_factory=list)
+    final_observation: object | None = None
 
 
 @jax.jit

--- a/swarmrl/utils/storage_utils/trajectory_storage.py
+++ b/swarmrl/utils/storage_utils/trajectory_storage.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict
 
+import h5py
 import numpy as np
 
 from swarmrl.utils.storage_utils.core_storage import HDF5TrajectoryStorage
@@ -11,12 +12,23 @@ from swarmrl.utils.storage_utils.core_storage import HDF5TrajectoryStorage
 class AgentTrajectoryStorage(HDF5TrajectoryStorage):
     """HDF5 storage for agent trajectory data with configurable fields."""
 
+    TIME_ALIGNED_FIELDS = {
+        "actions",
+        "log_probs",
+        "rewards",
+        "features",
+        "terminated",
+        "truncated",
+    }
+
     ALLOWED_FIELDS = {
         "actions",
         "log_probs",
         "rewards",
         "features",
-        "killed",
+        "terminated",
+        "truncated",
+        "final_observation",
     }
     PRESETS = {
         "minimal": ("actions", "rewards"),
@@ -25,7 +37,9 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
             "log_probs",
             "rewards",
             "features",
-            "killed",
+            "terminated",
+            "truncated",
+            "final_observation",
         ),
     }
     PRESETS["verbose"] = PRESETS["all"]
@@ -53,7 +67,8 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
             Ignored if stored_attributes is provided.
         stored_attributes : list (default=None)
             Explicit whitelist of attributes to store
-            (e.g., ["actions", "features"]).
+            (e.g., ["actions", "features", "terminated", "truncated",
+            "final_observation"]).
             Overrides preset if provided.
         allow_existing_file : bool (default=False)
             If False, raise FileExistsError when the target file already exists.
@@ -61,6 +76,13 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
         write_chunk_size : int (default=1)
             Number of complete agent trajectory samples buffered before appending to
             HDF5. The default 1 preserves immediate writes.
+
+        Notes
+        -----
+        Time-aligned trajectory fields may have different rollout (trainer episode)
+        lengths and are padded in storage. The ``trajectory_length`` dataset records
+        each original length. ``final_observation`` stores the bootstrap-only
+        observation after the last transition.
         """
         if stored_attributes is None:
             if preset not in self.PRESETS:
@@ -105,27 +127,34 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
         self.particle_type = particle_type
 
     def _get_dataset_specs(self, trajectory) -> Dict[str, Dict[str, Any]]:
-        specs = {}
+        trajectory_length = np.asarray(len(trajectory.rewards), dtype=np.int64)
+        specs = {
+            "trajectory_length": {
+                "shape": (1,),
+                "maxshape": (None,),
+                "dtype": trajectory_length.dtype,
+            }
+        }
 
         if "actions" in self.stored_attributes:
             actions = np.asarray(trajectory.actions)
             specs["actions"] = {
                 "shape": (1, *actions.shape),
-                "maxshape": (None, *actions.shape),
+                "maxshape": (None, None, *actions.shape[1:]),
                 "dtype": actions.dtype,
             }
         if "log_probs" in self.stored_attributes:
             log_probs = np.asarray(trajectory.log_probs)
             specs["log_probs"] = {
                 "shape": (1, *log_probs.shape),
-                "maxshape": (None, *log_probs.shape),
+                "maxshape": (None, None, *log_probs.shape[1:]),
                 "dtype": log_probs.dtype,
             }
         if "rewards" in self.stored_attributes:
             rewards = np.asarray(trajectory.rewards)
             specs["rewards"] = {
                 "shape": (1, *rewards.shape),
-                "maxshape": (None, *rewards.shape),
+                "maxshape": (None, None, *rewards.shape[1:]),
                 "dtype": rewards.dtype,
             }
 
@@ -135,21 +164,37 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
                 if features.size > 0:
                     specs["features"] = {
                         "shape": (1, *features.shape),
-                        "maxshape": (None, *features.shape),
+                        "maxshape": (None, None, *features.shape[1:]),
                         "dtype": features.dtype,
                     }
-        if "killed" in self.stored_attributes:
-            killed = np.asarray([trajectory.killed], dtype=np.bool_)
-            specs["killed"] = {
-                "shape": (1, 1),
-                "maxshape": (None, 1),
-                "dtype": killed.dtype,
+        if "terminated" in self.stored_attributes:
+            terminated = np.asarray(trajectory.terminated, dtype=np.bool_)
+            specs["terminated"] = {
+                "shape": (1, *terminated.shape),
+                "maxshape": (None, None, *terminated.shape[1:]),
+                "dtype": terminated.dtype,
+            }
+        if "truncated" in self.stored_attributes:
+            truncated = np.asarray(trajectory.truncated, dtype=np.bool_)
+            specs["truncated"] = {
+                "shape": (1, *truncated.shape),
+                "maxshape": (None, None, *truncated.shape[1:]),
+                "dtype": truncated.dtype,
+            }
+        if "final_observation" in self.stored_attributes:
+            final_observation = np.asarray(trajectory.final_observation)
+            specs["final_observation"] = {
+                "shape": (1, *final_observation.shape),
+                "maxshape": (None, *final_observation.shape),
+                "dtype": final_observation.dtype,
             }
 
         return specs
 
     def _extract_sample(self, trajectory) -> Dict[str, Any]:
-        sample = {}
+        sample = {
+            "trajectory_length": np.asarray(len(trajectory.rewards), dtype=np.int64)
+        }
 
         if "actions" in self.stored_attributes:
             sample["actions"] = trajectory.actions
@@ -157,8 +202,12 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
             sample["log_probs"] = trajectory.log_probs
         if "rewards" in self.stored_attributes:
             sample["rewards"] = trajectory.rewards
-        if "killed" in self.stored_attributes:
-            sample["killed"] = np.asarray([trajectory.killed], dtype=np.bool_)
+        if "terminated" in self.stored_attributes:
+            sample["terminated"] = np.asarray(trajectory.terminated, dtype=np.bool_)
+        if "truncated" in self.stored_attributes:
+            sample["truncated"] = np.asarray(trajectory.truncated, dtype=np.bool_)
+        if "final_observation" in self.stored_attributes:
+            sample["final_observation"] = trajectory.final_observation
 
         if "features" in self.stored_attributes:
             if getattr(trajectory, "features", None) is not None:
@@ -167,6 +216,41 @@ class AgentTrajectoryStorage(HDF5TrajectoryStorage):
                     sample["features"] = trajectory.features
 
         return sample
+
+    def _write_to_h5(self) -> None:
+        """Write agent trajectories, padding only their variable time axis."""
+        if not self._data_holder or all(
+            len(values) == 0 for values in self._data_holder.values()
+        ):
+            return
+
+        n_new = len(next(iter(self._data_holder.values())))
+        with h5py.File(self.h5_filename.as_posix(), "a", libver="latest") as h5_file:
+            group = h5_file[self._h5_group_tag]
+
+            for key, buffered_values in self._data_holder.items():
+                dataset = group[key]
+                dataset.resize(self._write_idx + n_new, axis=0)
+
+                if key in self.TIME_ALIGNED_FIELDS:
+                    arrays = [np.asarray(value) for value in buffered_values]
+                    max_length = max(
+                        dataset.shape[1], *(array.shape[0] for array in arrays)
+                    )
+                    if max_length > dataset.shape[1]:
+                        dataset.resize(max_length, axis=1)
+
+                    for offset, array in enumerate(arrays):
+                        row = self._write_idx + offset
+                        dataset[row, : array.shape[0]] = array
+                else:
+                    dataset[self._write_idx : self._write_idx + n_new] = np.stack(
+                        buffered_values, axis=0
+                    )
+
+            self._write_idx += n_new
+
+        self._data_holder = self._initialize_data_holder()
 
 
 @dataclass

--- a/swarmrl/value_functions/expected_returns.py
+++ b/swarmrl/value_functions/expected_returns.py
@@ -5,7 +5,7 @@ Module for the expected returns value function.
 from functools import partial
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 
 from swarmrl.utils.logging_utils import log_jax_runtime_value
 
@@ -35,48 +35,73 @@ class ExpectedReturns:
         self.standardize = standardize
 
         # Set by us to stabilize division operations.
-        self.eps = np.finfo(np.float32).eps.item()
+        self.eps = jnp.finfo(jnp.float32).eps.item()
 
     @partial(jax.jit, static_argnums=(0,))
-    def __call__(self, rewards: np.ndarray):
+    def __call__(
+        self,
+        rewards: jax.Array,
+        values: jax.Array,
+        terminated: jax.Array,
+        truncated: jax.Array,
+    ) -> jax.Array:
         """
         Call function for the expected returns.
         Parameters
         ----------
-        rewards : np.ndarray (n_time_steps, n_particles, dimension)
+        rewards : jax.Array (n_time_steps, n_particles, dimension)
                 A numpy array of rewards to use in the calculation.
+        values : jax.Array (n_time_steps + 1, n_particles)
+                Critic predictions for each action state and the final observation.
+        terminated : jax.Array (n_time_steps,)
+                Whether each transition ended in a terminal task state.
+        truncated : jax.Array (n_time_steps,)
+                Whether each transition ended because the environment was reset.
 
         Returns
         -------
-        expected_returns : np.ndarray (n_time_steps, n_particles)
+        expected_returns : jax.Array (n_time_steps, n_particles)
                 Expected returns for the rewards.
         """
         log_jax_runtime_value("gamma", self.gamma)
 
-        expected_returns = np.zeros_like(rewards)
-        n_particles = rewards.shape[1]
-
-        final_time = len(rewards) + 1
         log_jax_runtime_value("rewards", rewards)
 
-        for t, reward in enumerate(rewards):
-            gamma_array = self.gamma ** np.linspace(
-                t + 1, final_time, int(final_time - (t + 1)), dtype=int
+        def return_step(running_return, transition):
+            """
+            Boundary-aware return:
+            $G_t = r_t + gamma * ((1 - done_t) * G_(t+1) + truncated_t * V_(t+1))$.
+            Terminations use zero bootstrap; truncations bootstrap without crossing
+            the reset.
+            """
+            reward, next_value, is_terminated, is_truncated = transition
+            continuation = jnp.where(
+                is_truncated,
+                next_value,
+                running_return,
             )
-            gamma_array = np.transpose(
-                np.repeat(gamma_array[None, :], n_particles, axis=0)
+            continuation = jnp.where(
+                is_terminated,
+                jnp.zeros_like(continuation),
+                continuation,
             )
+            current_return = reward + self.gamma * continuation
+            return current_return, current_return
 
-            proceeding_rewards = rewards[t:, :]
-
-            returns = proceeding_rewards * gamma_array
-            expected_returns = expected_returns.at[t, :].set(returns.sum(axis=0))
+        # Seed the reverse scan with V(s_T) for rollout (trainer episode) bootstrapping.
+        # The scan step masks this value to zero when the final transition terminated.
+        _, expected_returns = jax.lax.scan(
+            return_step,
+            values[-1],
+            (rewards, values[1:], terminated, truncated),
+            reverse=True,
+        )
 
         log_jax_runtime_value("expected_returns", expected_returns)
 
         if self.standardize:
-            mean_vector = np.mean(expected_returns, axis=0)
-            std_vector = np.std(expected_returns, axis=0) + self.eps
+            mean_vector = jnp.mean(expected_returns, axis=0)
+            std_vector = jnp.std(expected_returns, axis=0) + self.eps
 
             expected_returns = (expected_returns - mean_vector) / std_vector
 

--- a/swarmrl/value_functions/generalized_advantage_estimate.py
+++ b/swarmrl/value_functions/generalized_advantage_estimate.py
@@ -4,8 +4,8 @@ Module for the expected returns value function.
 
 from functools import partial
 
-import jax.numpy as np
-from jax import jit
+import jax
+import jax.numpy as jnp
 
 
 class GAE:
@@ -33,37 +33,72 @@ class GAE:
         self.lambda_ = lambda_
 
         # Set by us to stabilize division operations.
-        self.eps = np.finfo(np.float32).eps.item()
+        self.eps = jnp.finfo(jnp.float32).eps.item()
 
-    @partial(jit, static_argnums=(0,))
-    def __call__(self, rewards: np.ndarray, values: np.ndarray):
+    @partial(jax.jit, static_argnums=(0,))
+    def __call__(
+        self,
+        rewards: jax.Array,
+        values: jax.Array,
+        terminated: jax.Array,
+        truncated: jax.Array,
+    ) -> tuple[jax.Array, jax.Array]:
         """
         Call function for the advantage.
         Parameters
         ----------
-        rewards : np.ndarray (n_time_steps, n_particles)
+        rewards : jax.Array (n_time_steps, n_particles)
                 A numpy array of rewards to use in the calculation.
-        values : np.ndarray (n_time_steps, n_particles)
-                The prediction of the critic for the episode.
+        values : jax.Array (n_time_steps + 1, n_particles)
+                Critic predictions for each action state and the final observation.
+        terminated : jax.Array (n_time_steps,)
+                Whether each transition ended in a terminal task state.
+        truncated : jax.Array (n_time_steps,)
+                Whether each transition ended because the environment was reset.
         Returns
         -------
-        advantages : np.ndarray (n_time_steps, n_particles)
-                Expected returns for the rewards.
+        advantages : jax.Array (n_time_steps, n_particles)
+                Standardized generalized advantages.
+        returns : jax.Array (n_time_steps, n_particles)
+                Boundary-aware critic targets before advantage standardization.
         """
-        gae = 0
-        advantages = np.zeros_like(rewards)
-        for t in reversed(range(len(rewards))):
-            if t != len(rewards) - 1:
-                delta = rewards[t] + self.gamma * values[t + 1] - values[t]
-            else:
-                delta = rewards[t] - values[t]
+        done = jnp.logical_or(terminated, truncated)
 
-            gae = delta + self.gamma * self.lambda_ * gae
-            advantages = advantages.at[t].set(gae)
+        def advantage_step(next_advantage, transition):
+            """
+            Boundary-aware generalized advantage estimate:
+            $delta_t = r_t + gamma * (1 - terminated_t) * V_(t+1) - V_t$.
+            $A_t = delta_t + gamma * lambda * (1 - done_t) * A_(t+1)$.
+            Terminations use zero bootstrap; both environment boundaries stop
+            advantage propagation.
+            """
+            reward, value, next_value, is_terminated, is_done = transition
+            bootstrap_value = jnp.where(
+                is_terminated,
+                jnp.zeros_like(next_value),
+                next_value,
+            )
+            delta = reward + self.gamma * bootstrap_value - value
+            continued_advantage = jnp.where(
+                is_done,
+                jnp.zeros_like(next_advantage),
+                next_advantage,
+            )
+            advantage = delta + self.gamma * self.lambda_ * continued_advantage
+            return advantage, advantage
 
-        returns = advantages + values
+        # There is no advantage beyond the rollout (trainer episode). The final delta
+        # still bootstraps from V(s_T), unless the final transition terminated.
+        _, advantages = jax.lax.scan(
+            advantage_step,
+            jnp.zeros_like(values[-1], dtype=jnp.result_type(rewards, values)),
+            (rewards, values[:-1], values[1:], terminated, done),
+            reverse=True,
+        )
+        # V(s_T) is bootstrap-only; returns align with the T action-producing states.
+        returns = advantages + values[:-1]
 
-        advantages = (advantages - np.mean(advantages)) / (
-            np.std(advantages) + self.eps
+        advantages = (advantages - jnp.mean(advantages)) / (
+            jnp.std(advantages) + self.eps
         )
         return advantages, returns


### PR DESCRIPTION
## Summary

This PR adds explicit trajectory-boundary semantics to SwarmRL. Actor-critic targets now distinguish task termination, environment truncation, and ordinary rollout boundaries.

## Changes

- Add `terminated`, `truncated`, and `final_observation` to trajectory information.
- Record the state reached after the final transition for critic bootstrapping.
- Update actor-critic agents to record rollout boundaries and preserve final observations across continuous rollout updates.
- Update episodic and continuous trainers to propagate task termination, mark scheduled resets as truncations, and pass shared-environment boundaries to all agents.
- When a task terminates during a time slice, complete and store that final transition without selecting another action. Episodic training then resets the environment, while continuous training ends.
- Bootstrap ordinary rollout boundaries and truncations from $V(s_T)$.
- Disable bootstrapping at true task terminations.
- Stop GAE and return propagation across environment boundaries.
- Fix the previous `ExpectedReturns` discount exponents, which incorrectly discounted immediate rewards and used nonconsecutive, absolute-time exponents when `gamma < 1`.
- Implement boundary-aware reverse recurrences for `ExpectedReturns` and GAE using `jax.lax.scan`.
- Detach critic return targets in policy-gradient and PPO losses using `jax.lax.stop_gradient`, preventing gradients through bootstrap values such as $V(s_T)$.
- Persist boundary flags, final observations, and trajectory lengths.
- Support variable-length trajectories in HDF5 storage through padding and explicit trajectory-length metadata.
- Standardize JAX NumPy imports to use the `jnp` alias.
- Add regression tests for trajectory boundaries, bootstrapping, gradient isolation, storage, and non-unit discount factors.
- Add an exact unstandardized return test with `gamma = 0.5` that detects the previous discounting bug.


## Verification
- Full unit suite `141 passed`
- Changes solve the chemotaxis task